### PR TITLE
Add new main menu for game selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,107 @@
       display: flex;
       flex-direction: column;
     }
+    body.menu-active header,
+    body.menu-active main,
+    body.menu-active footer {
+      display: none;
+    }
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+    .menu-screen {
+      display: none;
+      flex: 1;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 1.5rem;
+      background: radial-gradient(circle at top, rgba(120,160,255,0.12), transparent 55%);
+      min-height: 100vh;
+    }
+    body.menu-active .menu-screen {
+      display: flex;
+    }
+    .menu-content {
+      max-width: 960px;
+      width: 100%;
+      background: rgba(12,18,28,0.82);
+      border-radius: 1.25rem;
+      padding: 2.5rem clamp(1.5rem, 4vw, 3rem);
+      box-shadow: 0 24px 60px rgba(0,0,0,0.4);
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+    .menu-header h1 {
+      margin: 0 0 0.75rem;
+      font-size: clamp(2rem, 4vw, 2.75rem);
+    }
+    .menu-header p {
+      margin: 0;
+      color: rgba(245,247,250,0.8);
+      line-height: 1.7;
+      font-size: 1rem;
+    }
+    .menu-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+    }
+    .menu-card {
+      background: rgba(20,27,39,0.9);
+      border-radius: 1rem;
+      padding: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      border: 1px solid rgba(255,255,255,0.08);
+      position: relative;
+      overflow: hidden;
+    }
+    .menu-card::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top right, rgba(110,200,255,0.18), transparent 55%);
+      opacity: 0.6;
+      pointer-events: none;
+      z-index: 0;
+    }
+    .menu-card > * {
+      position: relative;
+      z-index: 1;
+    }
+    .menu-card h2 {
+      margin: 0;
+      font-size: 1.4rem;
+    }
+    .menu-card p {
+      margin: 0;
+      line-height: 1.6;
+      color: rgba(245,247,250,0.78);
+    }
+    .menu-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .menu-card.coming-soon {
+      align-items: flex-start;
+      justify-content: center;
+      color: rgba(245,247,250,0.5);
+    }
+    .menu-card.coming-soon::before {
+      background: radial-gradient(circle at top left, rgba(180,160,255,0.18), transparent 55%);
+    }
+    .menu-card.coming-soon span {
+      font-size: 0.9rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: rgba(255,255,255,0.08);
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+    }
     header {
       display: flex;
       flex-wrap: wrap;
@@ -248,12 +349,41 @@
       }
       header .stats { width: 100%; }
       .canvas-shell { width: min(100%, 520px); }
+      .menu-content {
+        padding: 2rem 1.25rem;
+      }
+      .menu-grid {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
-<body>
+<body class="menu-active">
+  <div class="menu-screen" id="menuScreen" role="dialog" aria-modal="true" aria-hidden="false">
+    <div class="menu-content">
+      <div class="menu-header">
+        <h1>ミニゲームセレクト</h1>
+        <p>これから少しずつゲームが増えていく予定です。まずは一筆書き迷路で腕試ししてみましょう！</p>
+      </div>
+      <div class="menu-grid">
+        <article class="menu-card">
+          <h2>一筆書き迷路</h2>
+          <p>スタートからゴールまで、同じ道を二度と通らずに駆け抜けるスピードラン型の迷路ゲームです。</p>
+          <div class="menu-actions">
+            <button id="menuStartBtn">ステージを選ぶ</button>
+            <button id="menuContinueBtn">続きから</button>
+          </div>
+        </article>
+        <article class="menu-card coming-soon" aria-hidden="true">
+          <span>COMING SOON</span>
+          <p>新しいゲームを準備中です。お楽しみに！</p>
+        </article>
+      </div>
+    </div>
+  </div>
   <header>
     <div class="controls">
+      <button id="menuReturnBtn" aria-label="メニューに戻る">メニュー</button>
       <button id="newGameBtn" aria-label="新しい迷路を生成">新しい迷路</button>
       <label class="badge" for="difficultySelect">難易度</label>
       <select id="difficultySelect" aria-label="難易度選択">
@@ -335,6 +465,11 @@
     const clearOverlay = $('#clearOverlay');
     const howToModal = $('#howToModal');
     const toastEl = $('#toast');
+    const menuScreen = $('#menuScreen');
+
+    const menuStartBtn = $('#menuStartBtn');
+    const menuContinueBtn = $('#menuContinueBtn');
+    const menuReturnBtn = $('#menuReturnBtn');
 
     const difficultySelect = $('#difficultySelect');
     const stageColumns = $('#stageColumns');
@@ -856,6 +991,7 @@
       const stageText = state.customStage ? 'カスタム' : `ステージ ${state.stage}`;
       statusLine.textContent = `${info.label} ${stageText} | シード ${state.stageSeed}`;
       localStorage.setItem('osm_continue', JSON.stringify({ difficulty, stage: state.stage, seed: state.stageSeed, custom: !!custom }));
+      updateMenuContinue();
       hideOverlays();
       playSound('start');
     }
@@ -955,8 +1091,9 @@
     function keyHandler(event) {
       if (event.repeat) return;
       if (event.key === 'Escape') {
+        if (document.body.classList.contains('menu-active')) return;
         if (state.grid) fail('リセット');
-      } else if (event.key === 'Enter' || event.key === ' ') {
+      } else if ((event.key === 'Enter' || event.key === ' ') && !document.body.classList.contains('menu-active')) {
         if (!state.runStarted && !homeOverlay.classList.contains('hidden')) {
           const data = getContinueData();
           if (data) startStage(data);
@@ -1501,12 +1638,74 @@
       }
     }
 
+    function updateMenuContinue() {
+      if (!menuContinueBtn) return;
+      const hasData = !!getContinueData();
+      menuContinueBtn.disabled = !hasData;
+      if (hasData) {
+        menuContinueBtn.removeAttribute('aria-disabled');
+      } else {
+        menuContinueBtn.setAttribute('aria-disabled', 'true');
+      }
+    }
+
+    function showMenu() {
+      document.body.classList.add('menu-active');
+      if (menuScreen) {
+        menuScreen.setAttribute('aria-hidden', 'false');
+      }
+      updateMenuContinue();
+    }
+
+    function enterMaze({ autoStart = false } = {}) {
+      document.body.classList.remove('menu-active');
+      if (menuScreen) {
+        menuScreen.setAttribute('aria-hidden', 'true');
+      }
+      clearOverlay.classList.add('hidden');
+      howToModal.classList.add('hidden');
+      if (!autoStart) {
+        homeOverlay.classList.remove('hidden');
+      }
+    }
+
+    function returnToMenu() {
+      hideOverlays();
+      resetState();
+      showMenu();
+    }
+
     function setupEvents() {
       canvas.addEventListener('pointerdown', pointerDown);
       window.addEventListener('pointermove', pointerMove);
       window.addEventListener('pointerup', pointerUp);
       window.addEventListener('pointercancel', pointerUp);
       window.addEventListener('keydown', keyHandler);
+
+      if (menuStartBtn) {
+        menuStartBtn.addEventListener('click', () => {
+          enterMaze({ autoStart: false });
+        });
+      }
+
+      if (menuContinueBtn) {
+        menuContinueBtn.addEventListener('click', () => {
+          const data = getContinueData();
+          if (data) {
+            enterMaze({ autoStart: true });
+            startStage(data);
+          } else {
+            enterMaze({ autoStart: false });
+            showToast('続きはありません');
+          }
+        });
+      }
+
+      if (menuReturnBtn) {
+        menuReturnBtn.addEventListener('click', () => {
+          returnToMenu();
+        });
+      }
 
       newGameBtn.addEventListener('click', () => {
         const diff = difficultySelect.value;
@@ -1590,13 +1789,17 @@
       }
     }
 
-    function initFromQuery() {
+    function initFromQuery({ autoStart = false } = {}) {
       const diffParam = params.get('difficulty');
       const stageParam = parseInt(params.get('stage'), 10);
       const seedParam = params.get('seed');
       const difficulty = diffParam && difficulties[diffParam] ? diffParam : 'easy';
       const stage = Number.isFinite(stageParam) ? stageParam : 1;
       difficultySelect.value = difficulty;
+      seedDifficulty.value = difficulty;
+      seedStage.value = String(Math.max(1, stage));
+      seedInput.value = seedParam ? seedParam : '';
+      if (!autoStart) return;
       if (seedParam) {
         startStage({ difficulty, stage, seed: seedParam, custom: true });
       } else {
@@ -1653,7 +1856,14 @@
       buildStageList();
       setupEvents();
       resize();
-      initFromQuery();
+      const shouldAutoStart = params.has('seed') || params.has('difficulty') || params.has('stage');
+      if (shouldAutoStart) {
+        enterMaze({ autoStart: true });
+        initFromQuery({ autoStart: true });
+      } else {
+        showMenu();
+        initFromQuery({ autoStart: false });
+      }
       animationHandle = requestAnimationFrame(loop);
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated landing menu that highlights the existing maze game and leaves space for future titles
- wire menu controls into the existing game flow, including a return button and continue shortcuts
- adjust initialization logic so query strings launch straight into the game while the default route shows the menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d21451ac7883278e00671b9a23abea