### PR TITLE
Improve mobile layouts for all games

### DIFF
--- a/echoes.html
+++ b/echoes.html
@@ -14,17 +14,27 @@
       --accent: #70d7ff;
       --accent-soft: rgba(112,215,255,0.22);
       --text: #f2f6fb;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
+      --page-padding: clamp(1rem, 3vw, 2rem);
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
+      min-height: 100dvh;
       background: var(--bg);
       display: flex;
       align-items: center;
       justify-content: center;
       color: var(--text);
-      padding: clamp(1rem, 3vw, 2rem);
+      padding: var(--page-padding);
+      padding-top: calc(var(--page-padding) + var(--safe-top));
+      padding-bottom: calc(var(--page-padding) + var(--safe-bottom));
+      padding-left: calc(var(--page-padding) + var(--safe-left));
+      padding-right: calc(var(--page-padding) + var(--safe-right));
     }
     .app {
       position: relative;
@@ -181,6 +191,8 @@
       pointer-events: none;
       transition: opacity 0.3s ease;
       padding: clamp(1.6rem, 4vw, 2.8rem);
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
     .overlay.active {
       opacity: 1;
@@ -196,6 +208,9 @@
       display: flex;
       flex-direction: column;
       gap: 1.2rem;
+      max-height: min(100%, 90vh);
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
     .panel h1, .panel h2, .panel h3 { margin: 0; letter-spacing: 0.05em; }
     .panel p { margin: 0; line-height: 1.7; color: rgba(242,246,251,0.82); }
@@ -343,6 +358,11 @@
       .stat-card { min-width: 120px; }
       .stat-card.small { min-width: calc(50% - 0.5rem); }
       .panel { padding: 1.4rem; }
+    }
+    @supports (height: 100dvh) {
+      .panel {
+        max-height: min(100%, 90dvh);
+      }
     }
   </style>
 </head>

--- a/floor99.html
+++ b/floor99.html
@@ -17,18 +17,27 @@
       --warning: #ffb449;
       --success: #5be0b5;
       --text: #f5f7fa;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
       font-family: 'Segoe UI', 'Hiragino Sans', sans-serif;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
+      min-height: 100dvh;
       display: flex;
       flex-direction: column;
       background: radial-gradient(circle at 20% 20%, rgba(100,160,255,0.25), transparent 60%),
                   radial-gradient(circle at 80% 10%, rgba(60,100,200,0.2), transparent 60%),
                   var(--bg);
       color: var(--text);
+      padding-top: var(--safe-top);
+      padding-bottom: var(--safe-bottom);
+      padding-left: var(--safe-left);
+      padding-right: var(--safe-right);
     }
     button {
       font: inherit;
@@ -74,7 +83,7 @@
       background: rgba(8, 14, 24, 0.84);
       backdrop-filter: blur(12px);
       position: sticky;
-      top: 0;
+      top: var(--safe-top);
       z-index: 20;
       box-shadow: 0 18px 36px rgba(0,0,0,0.35);
     }
@@ -202,6 +211,8 @@
       color: var(--text);
       transition: opacity 0.35s ease;
       z-index: 5;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
     .tower-overlay.hidden {
       opacity: 0;

--- a/index.html
+++ b/index.html
@@ -11,16 +11,26 @@
       --panel: rgba(20, 27, 39, 0.85);
       --accent: #6cf;
       --text: #f5f7fa;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
+      --page-padding: clamp(1.5rem, 4vw, 3rem);
       font-family: 'Segoe UI', 'Hiragino Sans', sans-serif;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
+      min-height: 100dvh;
       display: flex;
       justify-content: center;
       align-items: center;
-      padding: clamp(1.5rem, 4vw, 3rem);
+      padding: var(--page-padding);
+      padding-top: calc(var(--page-padding) + var(--safe-top));
+      padding-bottom: calc(var(--page-padding) + var(--safe-bottom));
+      padding-left: calc(var(--page-padding) + var(--safe-left));
+      padding-right: calc(var(--page-padding) + var(--safe-right));
       background: radial-gradient(circle at top, rgba(80,120,200,0.18), transparent 55%), var(--bg);
       color: var(--text);
     }
@@ -108,6 +118,10 @@
       opacity: 0.5;
     }
     @media (max-width: 640px) {
+      body {
+        justify-content: flex-start;
+        align-items: stretch;
+      }
       .menu-actions {
         width: 100%;
       }

--- a/maze.html
+++ b/maze.html
@@ -19,16 +19,25 @@
       --door-blue: #3f8cff;
       --door-red: #ff5f6d;
       --text: #f5f7fa;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
       font-family: 'Segoe UI', 'Hiragino Sans', sans-serif;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
+      min-height: 100dvh;
       background: radial-gradient(circle at top, rgba(80,120,200,0.18), transparent 55%), var(--bg);
       color: var(--text);
       display: flex;
       flex-direction: column;
+      padding-top: var(--safe-top);
+      padding-bottom: var(--safe-bottom);
+      padding-left: var(--safe-left);
+      padding-right: var(--safe-right);
     }
     button:disabled {
       cursor: not-allowed;
@@ -57,7 +66,7 @@
       background: rgba(8, 12, 20, 0.75);
       backdrop-filter: blur(12px);
       position: sticky;
-      top: 0;
+      top: var(--safe-top);
       z-index: 20;
     }
     header .controls {

--- a/metrorunner.html
+++ b/metrorunner.html
@@ -14,6 +14,11 @@
       --accent: #6cf5ff;
       --accent-soft: rgba(102,204,255,0.18);
       --text: #f5f7fa;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
+      --page-padding: clamp(1rem, 3vw, 2rem);
     }
     * {
       box-sizing: border-box;
@@ -21,12 +26,17 @@
     body {
       margin: 0;
       min-height: 100vh;
+      min-height: 100dvh;
       background: var(--bg);
       color: var(--text);
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: clamp(1rem, 3vw, 2rem);
+      padding: var(--page-padding);
+      padding-top: calc(var(--page-padding) + var(--safe-top));
+      padding-bottom: calc(var(--page-padding) + var(--safe-bottom));
+      padding-left: calc(var(--page-padding) + var(--safe-left));
+      padding-right: calc(var(--page-padding) + var(--safe-right));
     }
     .app {
       position: relative;
@@ -142,6 +152,8 @@
       pointer-events: none;
       transition: opacity 0.3s ease;
       padding: clamp(1.5rem, 4vw, 2.4rem);
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
     .overlay.active {
       opacity: 1;
@@ -157,6 +169,9 @@
       display: flex;
       flex-direction: column;
       gap: 1.2rem;
+      max-height: min(100%, 90vh);
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
     h1, h2, h3 {
       margin: 0;
@@ -336,6 +351,11 @@
       }
       button {
         flex: 1;
+      }
+    }
+    @supports (height: 100dvh) {
+      .panel {
+        max-height: min(100%, 90dvh);
       }
     }
   </style>

--- a/shooter.html
+++ b/shooter.html
@@ -19,16 +19,25 @@
       --door-blue: #3f8cff;
       --door-red: #ff5f6d;
       --text: #f5f7fa;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
       font-family: 'Segoe UI', 'Hiragino Sans', sans-serif;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
+      min-height: 100dvh;
       background: radial-gradient(circle at top, rgba(80,120,200,0.18), transparent 55%), var(--bg);
       color: var(--text);
       display: flex;
       flex-direction: column;
+      padding-top: var(--safe-top);
+      padding-bottom: var(--safe-bottom);
+      padding-left: var(--safe-left);
+      padding-right: var(--safe-right);
     }
     button, select {
       font: inherit;
@@ -75,7 +84,7 @@
       background: rgba(8, 12, 20, 0.78);
       backdrop-filter: blur(12px);
       position: sticky;
-      top: 0;
+      top: var(--safe-top);
       z-index: 30;
     }
     .shooter-controls {
@@ -156,9 +165,11 @@
       align-items: center;
       background: rgba(10, 14, 24, 0.92);
       color: var(--text);
-      padding: 1.5rem;
+      padding: clamp(1.2rem, 4vw, 2rem);
       gap: 1rem;
       text-align: center;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
     .shooter-overlay.hidden { display: none; }
     .shooter-panel {

--- a/swordsman.html
+++ b/swordsman.html
@@ -13,16 +13,25 @@
       --accent-strong: #4ec3ff;
       --danger: #ff6374;
       --text: #f5f7fa;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
       font-family: 'Segoe UI', 'Hiragino Sans', sans-serif;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       min-height: 100vh;
+      min-height: 100dvh;
       display: flex;
       flex-direction: column;
       background: radial-gradient(circle at top, rgba(90,140,220,0.25), transparent 55%), var(--bg);
       color: var(--text);
+      padding-top: var(--safe-top);
+      padding-bottom: var(--safe-bottom);
+      padding-left: var(--safe-left);
+      padding-right: var(--safe-right);
     }
     button {
       font: inherit;
@@ -68,7 +77,7 @@
       background: rgba(10, 15, 24, 0.82);
       backdrop-filter: blur(12px);
       position: sticky;
-      top: 0;
+      top: var(--safe-top);
       z-index: 20;
     }
     .blade-controls {
@@ -169,6 +178,8 @@
       color: var(--text);
       transition: opacity 0.35s ease;
       z-index: 4;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
     .blade-overlay h1 {
       margin: 0;


### PR DESCRIPTION
## Summary
- add safe-area aware padding and dynamic viewport sizing to every page so menus and sticky bars stay clear of smartphone notches
- allow full-screen overlays and panels to scroll with touch-friendly padding for narrow screens

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68d290dfb52c8327a509dffffa7e15bf