### PR TITLE
Improve mobile support for Metro Runner

### DIFF
--- a/metrorunner.html
+++ b/metrorunner.html
@@ -37,6 +37,8 @@
       padding-bottom: calc(var(--page-padding) + var(--safe-bottom));
       padding-left: calc(var(--page-padding) + var(--safe-left));
       padding-right: calc(var(--page-padding) + var(--safe-right));
+      font-size: clamp(14px, 1.7vw, 18px);
+      transition: font-size 0.2s ease;
     }
     .app {
       position: relative;
@@ -337,20 +339,108 @@
     .muted {
       opacity: 0.55;
     }
+    .orientation-overlay {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: calc(var(--page-padding) + var(--safe-top)) calc(var(--page-padding) + var(--safe-right)) calc(var(--page-padding) + var(--safe-bottom)) calc(var(--page-padding) + var(--safe-left));
+      background: rgba(6,10,18,0.94);
+      color: var(--text);
+      backdrop-filter: blur(16px);
+      z-index: 200;
+      text-align: center;
+    }
+    .orientation-overlay.show {
+      display: flex;
+    }
+    .orientation-panel {
+      max-width: min(360px, 100%);
+      background: rgba(12,18,30,0.92);
+      border-radius: 1.1rem;
+      border: 1px solid rgba(102,204,255,0.28);
+      padding: 1.4rem 1.6rem;
+      box-shadow: 0 22px 60px rgba(0,0,0,0.55);
+    }
+    .orientation-panel h2 {
+      margin: 0 0 0.6rem;
+      letter-spacing: 0.08em;
+      font-size: clamp(1rem, 2.6vw, 1.2rem);
+    }
+    .orientation-panel p {
+      margin: 0;
+      line-height: 1.6;
+      font-size: clamp(0.85rem, 2.2vw, 1rem);
+      opacity: 0.8;
+    }
+    body.orientation-blocked {
+      overflow: hidden;
+    }
     @media (max-width: 720px) {
+      body {
+        align-items: flex-start;
+      }
+      .app {
+        border-radius: 0.9rem;
+        box-shadow: 0 24px 60px rgba(0,0,0,0.5);
+      }
       .panel {
         padding: 1.6rem 1.2rem;
         border-radius: 1rem;
+        max-height: min(100%, 82vh);
       }
       .hud {
-        padding: 0.9rem;
+        padding: 0.8rem;
+        gap: 0.6rem;
+      }
+      .hud-row {
+        gap: 0.6rem;
       }
       .hud-card {
-        min-width: 100px;
-        padding: 0.45rem 0.7rem;
+        min-width: 92px;
+        padding: 0.45rem 0.65rem;
+      }
+      .hud-card strong {
+        font-size: 0.92rem;
+      }
+      .hud-card span,
+      .skill-bar-label {
+        font-size: 0.65rem;
+      }
+      .skill-bar {
+        min-width: 160px;
       }
       button {
         flex: 1;
+      }
+    }
+    @media (max-width: 560px) {
+      .hud-row {
+        flex-direction: column;
+      }
+      .hud-right {
+        width: 100%;
+        justify-content: flex-end;
+      }
+      .skill-bar {
+        width: 100%;
+      }
+      .button-row {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .mode-buttons {
+        flex-direction: column;
+      }
+      .mode-buttons button {
+        width: 100%;
+      }
+      button {
+        width: 100%;
+      }
+      .panel {
+        padding: 1.3rem 1rem;
       }
     }
     @supports (height: 100dvh) {
@@ -534,6 +624,13 @@
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
   </div>
 
+  <div id="orientationNotice" class="orientation-overlay" role="status" aria-live="polite">
+    <div class="orientation-panel">
+      <h2>横向きにしてプレイしてください</h2>
+      <p>スマートフォンでは端末を横向きにすると、画面全体で快適にゲームを楽しめます。</p>
+    </div>
+  </div>
+
   <script>
   (() => {
     const canvas = document.getElementById('gameCanvas');
@@ -571,6 +668,7 @@
     const upgradeList = document.getElementById('upgradeList');
 
     const toast = document.getElementById('toast');
+    const orientationNotice = document.getElementById('orientationNotice');
 
     const profileKey = 'metroRunnerProfile_v1';
     const defaultProfile = {
@@ -582,6 +680,26 @@
     };
 
     let profile = loadProfile();
+
+    function shouldShowOrientationNotice() {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      const isTouch = (navigator.maxTouchPoints || 0) > 0 || 'ontouchstart' in window;
+      if (!isTouch) return false;
+      if (!height) return false;
+      return width < height && width < 720;
+    }
+
+    function refreshOrientationNotice() {
+      if (!orientationNotice) return;
+      const show = shouldShowOrientationNotice();
+      orientationNotice.classList.toggle('show', show);
+      document.body.classList.toggle('orientation-blocked', show);
+    }
+
+    window.addEventListener('resize', refreshOrientationNotice, { passive: true });
+    window.addEventListener('orientationchange', () => setTimeout(refreshOrientationNotice, 120));
+    refreshOrientationNotice();
 
     const BASE_WIDTH = 1280;
     const BASE_HEIGHT = 720;


### PR DESCRIPTION
## Summary
- tune Metro Runner styles for small screens, including responsive HUD spacing and button layouts
- add a full-screen orientation notice overlay to guide smartphone users to rotate the device
- detect touch devices in portrait mode and toggle the orientation blocker while keeping the layout safe-area aware

## Testing
- not run (static HTML/CSS/JS change)


------
https://chatgpt.com/codex/tasks/task_e_68d2a43314a48327865e7a7c4ab5c35a