### PR TITLE
Improve Echoes mobile layout

### DIFF
--- a/echoes.html
+++ b/echoes.html
@@ -19,6 +19,8 @@
       --safe-bottom: env(safe-area-inset-bottom, 0px);
       --safe-left: env(safe-area-inset-left, 0px);
       --page-padding: clamp(1rem, 3vw, 2rem);
+      --overlay-padding: clamp(1.6rem, 4vw, 2.8rem);
+      --touch-padding: clamp(0.8rem, 4vw, 1.6rem);
     }
     * { box-sizing: border-box; }
     body {
@@ -190,9 +192,10 @@
       opacity: 0;
       pointer-events: none;
       transition: opacity 0.3s ease;
-      padding: clamp(1.6rem, 4vw, 2.8rem);
+      padding: var(--overlay-padding);
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
+      z-index: 10;
     }
     .overlay.active {
       opacity: 1;
@@ -208,7 +211,7 @@
       display: flex;
       flex-direction: column;
       gap: 1.2rem;
-      max-height: min(100%, 90vh);
+      max-height: min(100%, 90vh, 90dvh);
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
     }
@@ -232,7 +235,10 @@
       display: none;
       justify-content: space-between;
       align-items: flex-end;
-      padding: clamp(0.8rem, 4vw, 1.6rem);
+      padding: var(--touch-padding);
+      padding-bottom: calc(var(--touch-padding) + var(--safe-bottom));
+      padding-left: calc(var(--touch-padding) + var(--safe-left));
+      padding-right: calc(var(--touch-padding) + var(--safe-right));
       pointer-events: none;
       opacity: 0;
       transition: opacity 0.25s ease;
@@ -354,14 +360,175 @@
     }
     .result-stats span { font-size: 0.75rem; opacity: 0.7; }
     .result-stats strong { font-size: 1.1rem; }
-    @media (max-width: 720px) {
-      .stat-card { min-width: 120px; }
-      .stat-card.small { min-width: calc(50% - 0.5rem); }
-      .panel { padding: 1.4rem; }
+    @media (max-width: 900px) {
+      body {
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: center;
+      }
     }
-    @supports (height: 100dvh) {
+
+    @media (max-width: 720px) {
+      :root {
+        --page-padding: clamp(0.85rem, 4vw, 1.4rem);
+        --overlay-padding: clamp(1.3rem, 5vw, 2.2rem);
+        --touch-padding: clamp(0.7rem, 5vw, 1.4rem);
+      }
+      .hud-layer {
+        padding: clamp(0.9rem, 4vw, 1.2rem);
+        gap: 0.6rem;
+      }
+      .top-stats {
+        gap: 0.6rem;
+      }
+      .stat-card {
+        min-width: 120px;
+        padding: 0.55rem 0.75rem;
+      }
+      .stat-card.small {
+        min-width: calc(50% - 0.4rem);
+      }
+      .stat-card span {
+        font-size: 0.65rem;
+      }
+      .stat-card strong {
+        font-size: 0.9rem;
+      }
+      .bar {
+        height: 12px;
+      }
+      .skill-strip {
+        gap: 0.4rem;
+      }
+      .skill-strip span {
+        font-size: 0.64rem;
+        padding: 0.28rem 0.55rem;
+      }
+      .hud-buttons {
+        gap: 0.4rem;
+      }
+      .hud-buttons button {
+        padding: 0.4rem 0.75rem;
+        font-size: 0.74rem;
+      }
+      .message {
+        max-width: 84%;
+        font-size: 0.78rem;
+      }
+      .overlay {
+        position: fixed;
+        inset: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left);
+        place-items: start center;
+        align-content: start;
+      }
       .panel {
-        max-height: min(100%, 90dvh);
+        width: min(560px, 100%);
+        max-height: calc(100vh - var(--safe-top) - var(--safe-bottom) - var(--overlay-padding) * 2);
+      }
+      .touch-controls {
+        gap: clamp(0.85rem, 6vw, 1.6rem);
+      }
+      .touch-controls .touch-panel.left,
+      .touch-controls .touch-panel.right,
+      .touch-controls .touch-move,
+      .touch-controls .touch-move-row {
+        gap: clamp(0.4rem, 4vw, 0.8rem);
+      }
+      @supports (height: 100dvh) {
+        .panel {
+          max-height: calc(100dvh - var(--safe-top) - var(--safe-bottom) - var(--overlay-padding) * 2);
+        }
+      }
+    }
+
+    @media (max-width: 540px) {
+      .app {
+        border-radius: 0.9rem;
+      }
+      .hud-layer {
+        padding: clamp(0.75rem, 4vw, 1.05rem);
+        gap: 0.5rem;
+      }
+      .top-stats {
+        gap: 0.5rem;
+      }
+      .stat-card {
+        min-width: calc(50% - 0.4rem);
+        padding: 0.5rem 0.65rem;
+      }
+      .stat-card.small {
+        min-width: calc(50% - 0.4rem);
+      }
+      .stat-card span {
+        font-size: 0.6rem;
+      }
+      .stat-card strong {
+        font-size: 0.82rem;
+      }
+      .bar {
+        height: 10px;
+      }
+      .skill-strip {
+        gap: 0.3rem;
+      }
+      .skill-strip span {
+        font-size: 0.58rem;
+        padding: 0.24rem 0.45rem;
+      }
+      .hud-buttons {
+        flex-wrap: wrap;
+      }
+      .hud-buttons button {
+        flex: 1 1 calc(50% - 0.4rem);
+        min-width: 0;
+        font-size: 0.7rem;
+        padding: 0.4rem 0.6rem;
+      }
+      .message {
+        font-size: 0.72rem;
+        padding: 0.45rem 0.7rem;
+        max-width: 90%;
+      }
+      .touch-controls {
+        gap: clamp(0.7rem, 7vw, 1.2rem);
+      }
+      .touch-controls button {
+        min-width: clamp(46px, 16vw, 64px);
+        min-height: clamp(46px, 16vw, 64px);
+        font-size: clamp(0.76rem, 3.8vw, 0.96rem);
+      }
+      .touch-controls button.small {
+        min-width: clamp(38px, 14vw, 52px);
+        min-height: clamp(38px, 14vw, 52px);
+        font-size: clamp(0.66rem, 3.2vw, 0.88rem);
+      }
+      .touch-controls button.action {
+        min-width: clamp(48px, 18vw, 68px);
+        min-height: clamp(48px, 18vw, 68px);
+      }
+      .touch-controls button.attack {
+        font-size: clamp(0.95rem, 5vw, 1.25rem);
+      }
+      .panel h1 {
+        font-size: 1.35rem;
+      }
+      .panel h2 {
+        font-size: 1.15rem;
+      }
+      .panel p,
+      .panel ul {
+        font-size: 0.9rem;
+      }
+      .panel-footer {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .panel-footer button {
+        width: 100%;
+        min-width: 0;
+      }
+      .result-stats {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- adjust the Echoes of City overlay and touch control styling to use shared padding variables and respect safe areas
- add responsive breakpoints so HUD panels, overlays, and touch buttons adapt to narrow smartphone viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2a44ef5408327991803aa505843eb