### PR TITLE
Add Swap Monsters evolution puzzle

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,6 +190,13 @@
             <button id="menuDeadzoneBtn" type="button">サバイバル開始</button>
           </div>
         </article>
+        <article class="menu-card">
+          <h2>スワップ・モンスターズ</h2>
+          <p>隣接するモンスターをスワップして進化させる連鎖型マッチパズル。爆弾やレインボーエッグを駆使し、進化図鑑とランキングを埋め尽くそう。</p>
+          <div class="menu-actions">
+            <button id="menuSwapBtn" type="button">進化パズル</button>
+          </div>
+        </article>
       </div>
     </div>
   </div>
@@ -204,6 +211,7 @@
     const runnerBtn = document.getElementById('menuRunnerBtn');
     const echoesBtn = document.getElementById('menuEchoesBtn');
     const deadzoneBtn = document.getElementById('menuDeadzoneBtn');
+    const swapBtn = document.getElementById('menuSwapBtn');
 
     function getContinueData() {
       try {
@@ -276,6 +284,12 @@
     if (deadzoneBtn) {
       deadzoneBtn.addEventListener('click', () => {
         window.location.href = 'deadzone.html';
+      });
+    }
+
+    if (swapBtn) {
+      swapBtn.addEventListener('click', () => {
+        window.location.href = 'swapmonsters.html';
       });
     }
 

--- a/swapmonsters.html
+++ b/swapmonsters.html
@@ -1,0 +1,1623 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>スワップ・モンスターズ</title>
+  <style>
+    :root {
+      color-scheme: dark light;
+      --bg: radial-gradient(circle at 20% -10%, rgba(145, 96, 255, 0.22), transparent 60%),
+              radial-gradient(circle at 80% 0%, rgba(70, 200, 255, 0.18), transparent 55%),
+              #0e1018;
+      --panel: rgba(16, 20, 32, 0.78);
+      --accent: #7df5ff;
+      --accent-strong: #ff96f5;
+      --text: #f5f7fa;
+      --muted: rgba(245, 247, 250, 0.7);
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
+      font-family: 'Segoe UI', 'Hiragino Sans', 'Noto Sans JP', sans-serif;
+    }
+    * {
+      box-sizing: border-box;
+      touch-action: manipulation;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      min-height: 100dvh;
+      background: var(--bg);
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      padding: clamp(1rem, 3vw, 2rem);
+      padding-top: calc(clamp(1rem, 3vw, 2rem) + var(--safe-top));
+      padding-bottom: calc(clamp(1rem, 3vw, 2rem) + var(--safe-bottom));
+      padding-left: calc(clamp(1rem, 3vw, 2rem) + var(--safe-left));
+      padding-right: calc(clamp(1rem, 3vw, 2rem) + var(--safe-right));
+      gap: clamp(1rem, 2.5vw, 1.75rem);
+      overflow: hidden;
+    }
+    header {
+      display: grid;
+      gap: 0.75rem;
+      background: rgba(10, 14, 26, 0.72);
+      padding: 0.85rem 1rem;
+      border-radius: 1rem;
+      box-shadow: 0 18px 42px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(14px);
+    }
+    header .top-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header h1 {
+      margin: 0;
+      font-size: clamp(1.8rem, 3.6vw, 2.4rem);
+    }
+    header p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.6;
+      font-size: 0.95rem;
+      max-width: 720px;
+    }
+    .hud {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.65rem;
+      width: 100%;
+    }
+    .hud .hud-tile {
+      background: rgba(255, 255, 255, 0.06);
+      border-radius: 0.75rem;
+      padding: 0.65rem 0.85rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.3rem;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+    }
+    .hud .hud-tile strong {
+      font-size: 1.1rem;
+    }
+    .time-bar {
+      width: 100%;
+      height: 0.55rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.12);
+      overflow: hidden;
+      position: relative;
+    }
+    .time-bar span {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, #7df5ff, #6f85ff, #ff96f5);
+      transform-origin: left center;
+      transform: scaleX(1);
+      transition: transform 0.2s ease;
+    }
+    main {
+      flex: 1;
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.5rem);
+      grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+    }
+    .board-shell {
+      position: relative;
+      background: rgba(10, 14, 24, 0.78);
+      border-radius: 1.25rem;
+      padding: clamp(1rem, 2vw, 1.25rem);
+      display: flex;
+      align-items: stretch;
+      justify-content: center;
+      overflow: hidden;
+      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
+    }
+    .board {
+      width: min(88vw, 640px);
+      aspect-ratio: 1 / 1;
+      display: grid;
+      grid-template-columns: repeat(var(--size), 1fr);
+      gap: clamp(0.25rem, 1.4vw, 0.5rem);
+      position: relative;
+      user-select: none;
+      touch-action: none;
+    }
+    .tile {
+      position: relative;
+      border: none;
+      border-radius: 0.9rem;
+      background: rgba(255, 255, 255, 0.08);
+      color: inherit;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 0.15rem;
+      font-weight: 600;
+      padding: 0.4rem;
+      cursor: pointer;
+      transition: transform 0.15s ease, filter 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+      overflow: hidden;
+      touch-action: none;
+    }
+    .tile::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      opacity: 0;
+      background: radial-gradient(circle at center, rgba(255, 255, 255, 0.38), transparent 70%);
+      transition: opacity 0.2s ease;
+      pointer-events: none;
+    }
+    .tile span.label {
+      font-size: clamp(0.7rem, 1.8vw, 0.95rem);
+      text-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
+    }
+    .tile span.level {
+      font-size: clamp(0.6rem, 1.6vw, 0.8rem);
+      opacity: 0.8;
+    }
+    .tile.selected {
+      transform: scale(1.04);
+      filter: brightness(1.1);
+      box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.45), 0 12px 24px rgba(0, 0, 0, 0.35);
+    }
+    .tile.highlight::after {
+      opacity: 1;
+      animation: pulse 0.4s ease alternate infinite;
+    }
+    .tile.frozen {
+      cursor: not-allowed;
+    }
+    .tile.frozen::before {
+      content: '\\2744';
+      position: absolute;
+      font-size: clamp(1.4rem, 3vw, 1.8rem);
+      inset: 0;
+      display: grid;
+      place-items: center;
+      color: rgba(255, 255, 255, 0.95);
+      text-shadow: 0 0 10px rgba(90, 210, 255, 0.8);
+      backdrop-filter: blur(2px);
+      pointer-events: none;
+    }
+    .tile.special-bomb::after {
+      opacity: 1;
+      background: radial-gradient(circle at center, rgba(255, 240, 170, 0.5), transparent 65%);
+    }
+    .tile.special-rainbow {
+      animation: rainbowCycle 2.2s linear infinite;
+    }
+    .tile.chain-surge {
+      animation: surge 0.45s ease;
+    }
+    canvas.fx-layer {
+      position: absolute;
+      inset: clamp(1rem, 2vw, 1.25rem);
+      width: calc(100% - clamp(1rem, 2vw, 1.25rem) * 2);
+      height: calc(100% - clamp(1rem, 2vw, 1.25rem) * 2);
+      pointer-events: none;
+    }
+    .side-panel {
+      background: rgba(10, 14, 24, 0.68);
+      border-radius: 1.25rem;
+      padding: clamp(1rem, 2vw, 1.35rem);
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+      box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+      overflow: hidden;
+    }
+    .panel-block {
+      display: flex;
+      flex-direction: column;
+      gap: 0.65rem;
+    }
+    .panel-block h2 {
+      margin: 0;
+      font-size: 1.1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+    .panel-block h2 span {
+      font-size: 0.85rem;
+      font-weight: 500;
+      color: var(--muted);
+    }
+    .codex-list,
+    .achievement-list,
+    .ranking-list {
+      display: grid;
+      gap: 0.45rem;
+    }
+    .codex-entry,
+    .achievement,
+    .ranking-entry {
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 0.85rem;
+      padding: 0.55rem 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      font-size: 0.85rem;
+    }
+    .codex-entry.unlocked {
+      border: 1px solid rgba(125, 245, 255, 0.4);
+      box-shadow: 0 0 14px rgba(125, 245, 255, 0.18);
+    }
+    .codex-entry .name-line {
+      display: flex;
+      justify-content: space-between;
+      gap: 0.35rem;
+      font-weight: 600;
+    }
+    .achievement.completed {
+      border: 1px solid rgba(255, 240, 170, 0.35);
+      box-shadow: 0 0 14px rgba(255, 240, 170, 0.2);
+    }
+    .achievement .status {
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+    .ranking-entry strong {
+      font-size: 1.05rem;
+    }
+    .status-bar {
+      min-height: 1.4rem;
+      font-size: 0.95rem;
+      color: var(--muted);
+      display: flex;
+      align-items: center;
+    }
+    .combo-banner {
+      position: fixed;
+      top: clamp(2.5rem, 6vw, 5rem);
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 0.65rem 1.25rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.15);
+      backdrop-filter: blur(12px);
+      box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+      font-size: clamp(1rem, 3vw, 1.4rem);
+      font-weight: 700;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+    }
+    .combo-banner.active {
+      opacity: 1;
+      transform: translate(-50%, -0.5rem);
+    }
+    .overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(8, 12, 20, 0.92);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(1.5rem, 4vw, 3rem);
+      text-align: center;
+      gap: 1.35rem;
+      z-index: 30;
+      color: var(--text);
+    }
+    .overlay.hidden {
+      display: none;
+    }
+    .overlay h1 {
+      font-size: clamp(2rem, 5vw, 2.8rem);
+      margin: 0;
+    }
+    .overlay p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.6;
+      max-width: 540px;
+    }
+    .overlay .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      justify-content: center;
+    }
+    button, .overlay button {
+      font: inherit;
+      border-radius: 0.75rem;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      background: rgba(255, 255, 255, 0.12);
+      color: inherit;
+      padding: 0.6rem 1.25rem;
+      cursor: pointer;
+      transition: transform 0.12s ease, background 0.18s ease, box-shadow 0.18s ease;
+    }
+    button:hover:not(:disabled) {
+      background: rgba(255, 255, 255, 0.2);
+      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
+    }
+    button:active:not(:disabled) {
+      transform: scale(0.97);
+    }
+    .back-link {
+      align-self: flex-start;
+      text-decoration: none;
+      color: inherit;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.9rem;
+      padding: 0.4rem 0.75rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+    }
+    .result-stats {
+      display: grid;
+      gap: 0.75rem;
+      width: min(480px, 100%);
+    }
+    .result-stats .stat {
+      background: rgba(255, 255, 255, 0.08);
+      padding: 0.75rem 1rem;
+      border-radius: 0.9rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    body.shake {
+      animation: shake 0.3s linear;
+    }
+    @keyframes shake {
+      0%, 100% { transform: translate3d(0, 0, 0); }
+      25% { transform: translate3d(-6px, 3px, 0); }
+      50% { transform: translate3d(5px, -4px, 0); }
+      75% { transform: translate3d(-4px, -3px, 0); }
+    }
+    @keyframes pulse {
+      from { opacity: 0.3; }
+      to { opacity: 0.8; }
+    }
+    @keyframes rainbowCycle {
+      0% { filter: hue-rotate(0deg) brightness(1.05); }
+      50% { filter: hue-rotate(180deg) brightness(1.1); }
+      100% { filter: hue-rotate(360deg) brightness(1.05); }
+    }
+    @keyframes surge {
+      0% { transform: scale(1); }
+      40% { transform: scale(1.08); }
+      100% { transform: scale(1); }
+    }
+    @media (max-width: 1024px) {
+      main {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto auto;
+      }
+      .board {
+        width: min(94vw, 520px);
+      }
+    }
+    @media (max-width: 640px) {
+      body {
+        padding: 1rem;
+      }
+      header .top-row {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .hud {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      }
+      .board-shell {
+        padding: 0.75rem;
+      }
+      .board {
+        gap: 0.25rem;
+      }
+      .tile {
+        border-radius: 0.6rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="back-link" href="index.html">&larr; メニューへ戻る</a>
+  <header>
+    <div class="top-row">
+      <h1>スワップ・モンスターズ</h1>
+      <button id="restartBtn" type="button">リスタート</button>
+    </div>
+    <p>隣接するモンスターをスワップして3体揃え、進化の連鎖を巻き起こそう。コンボと特殊進化で図鑑を埋め、ランキング上位を目指してスコアを伸ばしていきましょう。</p>
+    <div class="hud">
+      <div class="hud-tile">
+        <span>スコア</span>
+        <strong id="scoreValue">0</strong>
+      </div>
+      <div class="hud-tile">
+        <span>残り時間</span>
+        <strong><span id="timeValue">120</span>s</strong>
+        <div class="time-bar"><span id="timeBar"></span></div>
+      </div>
+      <div class="hud-tile">
+        <span>最大進化</span>
+        <strong id="maxEvolution">-</strong>
+      </div>
+      <div class="hud-tile">
+        <span>最大コンボ</span>
+        <strong id="maxCombo">0</strong>
+      </div>
+    </div>
+  </header>
+  <main>
+    <div class="board-shell">
+      <div class="board" id="board" aria-label="ゲームボード" role="grid"></div>
+      <canvas class="fx-layer" id="fxCanvas"></canvas>
+    </div>
+    <aside class="side-panel">
+      <div class="panel-block">
+        <h2>進化図鑑 <span>作成済みモンスター</span></h2>
+        <div class="codex-list" id="codexList"></div>
+      </div>
+      <div class="panel-block">
+        <h2>実績 <span>条件を満たして解除</span></h2>
+        <div class="achievement-list" id="achievementList"></div>
+      </div>
+      <div class="panel-block">
+        <h2>ランキング <span>ローカル保存</span></h2>
+        <div class="ranking-list" id="rankingList"></div>
+      </div>
+      <div class="status-bar" id="statusBar"></div>
+    </aside>
+  </main>
+  <div class="combo-banner" id="comboBanner"></div>
+  <div class="overlay" id="startOverlay">
+    <h1>スワップ・モンスターズ</h1>
+    <p>ボード上のモンスターをスワップして3体揃えると融合し、より強力な進化モンスターが誕生します。爆弾やレインボーエッグを活用しながら、時間内に最強モンスターを生み出そう！</p>
+    <div class="actions">
+      <button id="startBtn" type="button">ゲームスタート</button>
+    </div>
+  </div>
+  <div class="overlay hidden" id="resultOverlay">
+    <h1>リザルト</h1>
+    <div class="result-stats">
+      <div class="stat"><span>最終スコア</span><strong id="resultScore">0</strong></div>
+      <div class="stat"><span>最大進化モンスター</span><strong id="resultEvolution">-</strong></div>
+      <div class="stat"><span>最大コンボ</span><strong id="resultCombo">0</strong></div>
+    </div>
+    <p id="resultMessage">次はさらに進化連鎖を狙おう！</p>
+    <div class="actions">
+      <button id="retryBtn" type="button">もう一度</button>
+      <button id="resultMenuBtn" type="button" onclick="window.location.href='index.html'">メニューに戻る</button>
+    </div>
+  </div>
+  <script>
+    (() => {
+      const BOARD_SIZE = 8;
+      const TIME_LIMIT = 120;
+      const BASE_SCORE = 120;
+      const COMBO_STEP = 0.45;
+      const BOMB_RADIUS = 1;
+      const SPECIAL_PROB = {
+        bomb: 0.07,
+        rainbow: 0.045,
+        frozen: 0.08
+      };
+      const STORAGE_KEYS = {
+        ranking: 'swapmonsters_ranking',
+        achievements: 'swapmonsters_achievements',
+        codex: 'swapmonsters_codex'
+      };
+
+      const elements = [
+        { id: 'aqua', label: 'アクア', colors: ['#4ecbff', '#2a6dff'], glow: 'rgba(110, 210, 255, 0.65)' },
+        { id: 'ember', label: 'エンバー', colors: ['#ff8b5d', '#ff3d7f'], glow: 'rgba(255, 120, 90, 0.6)' },
+        { id: 'terra', label: 'テラ', colors: ['#5dff9e', '#1fba7f'], glow: 'rgba(120, 255, 200, 0.6)' },
+        { id: 'volt', label: 'ヴォルト', colors: ['#ffe76d', '#ff7b1f'], glow: 'rgba(255, 235, 120, 0.62)' },
+        { id: 'myst', label: 'ミスト', colors: ['#c18bff', '#7139ff'], glow: 'rgba(170, 120, 255, 0.65)' }
+      ];
+
+      const evolutionStages = [
+        { level: 1, name: 'スライム', flair: 'ぷるぷる' },
+        { level: 2, name: 'ゴブリン', flair: '素早い' },
+        { level: 3, name: 'オーク', flair: '剛腕' },
+        { level: 4, name: 'ドラゴン', flair: '火炎' },
+        { level: 5, name: 'フェニックス', flair: '不死鳥' },
+        { level: 6, name: 'キメラ', flair: '禁断' }
+      ];
+      const maxLevel = evolutionStages[evolutionStages.length - 1].level;
+
+      const achievementDefs = [
+        { id: 'combo10', name: '10連鎖達成', description: 'コンボを10まで繋げる', condition: (ctx) => ctx.maxCombo >= 10 },
+        { id: 'combo15', name: '15連鎖達成', description: 'コンボを15まで繋げる', condition: (ctx) => ctx.maxCombo >= 15 },
+        { id: 'dragonBorn', name: 'ドラゴン誕生', description: 'ドラゴン以上を進化させる', condition: (ctx) => ctx.bestLevel >= 4 },
+        { id: 'phoenix', name: 'フェニックス覚醒', description: 'フェニックスを誕生させる', condition: (ctx) => ctx.bestLevel >= 5 },
+        { id: 'chimera', name: 'キメラ融合', description: 'キメラを誕生させる', condition: (ctx) => ctx.bestLevel >= 6 },
+        { id: 'score50k', name: 'スコア5万突破', description: '最終スコアが50,000以上', condition: (ctx) => ctx.score >= 50000 },
+        { id: 'score100k', name: 'スコア10万突破', description: '最終スコアが100,000以上', condition: (ctx) => ctx.score >= 100000 },
+        { id: 'frozenBreak', name: '凍結解除マスター', description: '凍結モンスターを10体解除', condition: (ctx) => ctx.unfrozen >= 10 },
+        { id: 'bombChain', name: '爆連鎖職人', description: '爆弾で5回以上連鎖を発生させる', condition: (ctx) => ctx.bombChains >= 5 }
+      ];
+
+      const boardEl = document.getElementById('board');
+      const scoreEl = document.getElementById('scoreValue');
+      const timeEl = document.getElementById('timeValue');
+      const timeBarEl = document.getElementById('timeBar');
+      const maxEvolutionEl = document.getElementById('maxEvolution');
+      const maxComboEl = document.getElementById('maxCombo');
+      const codexListEl = document.getElementById('codexList');
+      const achievementListEl = document.getElementById('achievementList');
+      const rankingListEl = document.getElementById('rankingList');
+      const statusBarEl = document.getElementById('statusBar');
+      const comboBannerEl = document.getElementById('comboBanner');
+      const fxCanvas = document.getElementById('fxCanvas');
+      const startOverlay = document.getElementById('startOverlay');
+      const resultOverlay = document.getElementById('resultOverlay');
+      const resultScoreEl = document.getElementById('resultScore');
+      const resultEvolutionEl = document.getElementById('resultEvolution');
+      const resultComboEl = document.getElementById('resultCombo');
+      const resultMessageEl = document.getElementById('resultMessage');
+      const startBtn = document.getElementById('startBtn');
+      const retryBtn = document.getElementById('retryBtn');
+      const restartBtn = document.getElementById('restartBtn');
+
+      let grid = [];
+      let tileEls = [];
+      let selectedTile = null;
+      let pointerState = null;
+      let busy = false;
+      let gameActive = false;
+      let startTimestamp = 0;
+      let score = 0;
+      let comboChain = 0;
+      let maxCombo = 0;
+      let bestLevel = 1;
+      let frozenReleased = 0;
+      let bombChains = 0;
+      let timerFrame = null;
+      let codexState = loadFromStorage(STORAGE_KEYS.codex, {});
+      let achievementsState = loadFromStorage(STORAGE_KEYS.achievements, {});
+      let rankingState = loadFromStorage(STORAGE_KEYS.ranking, []);
+      let audio = null;
+      let fxCtx = fxCanvas.getContext('2d');
+      let particles = [];
+      let comboBannerTimer = null;
+
+      if (!codexState || typeof codexState !== 'object') codexState = {};
+      if (!achievementsState || typeof achievementsState !== 'object') achievementsState = {};
+      if (!Array.isArray(rankingState)) rankingState = [];
+
+      const ctxStats = {
+        get score() { return score; },
+        get maxCombo() { return maxCombo; },
+        get bestLevel() { return bestLevel; },
+        get unfrozen() { return frozenReleased; },
+        get bombChains() { return bombChains; }
+      };
+
+      function loadFromStorage(key, fallback) {
+        try {
+          const raw = localStorage.getItem(key);
+          if (!raw) return fallback;
+          const parsed = JSON.parse(raw);
+          return parsed ?? fallback;
+        } catch (err) {
+          return fallback;
+        }
+      }
+
+      function saveToStorage(key, value) {
+        try {
+          localStorage.setItem(key, JSON.stringify(value));
+        } catch (err) {
+          // ignore
+        }
+      }
+
+      function initBoardElements() {
+        boardEl.style.setProperty('--size', BOARD_SIZE);
+        boardEl.innerHTML = '';
+        tileEls = new Array(BOARD_SIZE).fill(null).map(() => new Array(BOARD_SIZE).fill(null));
+        for (let r = 0; r < BOARD_SIZE; r++) {
+          for (let c = 0; c < BOARD_SIZE; c++) {
+            const btn = document.createElement('button');
+            btn.className = 'tile';
+            btn.type = 'button';
+            btn.setAttribute('data-row', r);
+            btn.setAttribute('data-col', c);
+            btn.setAttribute('role', 'gridcell');
+            btn.addEventListener('pointerdown', handlePointerDown);
+            btn.addEventListener('pointermove', handlePointerMove);
+            btn.addEventListener('pointerup', handlePointerUp);
+            btn.addEventListener('pointercancel', handlePointerUp);
+            btn.addEventListener('keydown', handleTileKey);
+            boardEl.appendChild(btn);
+            tileEls[r][c] = btn;
+          }
+        }
+        resizeFxCanvas();
+      }
+
+      function createTile(row, col, level = 1) {
+        const element = Math.floor(Math.random() * elements.length);
+        const tile = {
+          id: crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`,
+          row,
+          col,
+          element,
+          level,
+          special: null,
+          frozen: false
+        };
+        if (level === 1) {
+          const roll = Math.random();
+          if (roll < SPECIAL_PROB.rainbow) {
+            tile.special = 'rainbow';
+          } else if (roll < SPECIAL_PROB.rainbow + SPECIAL_PROB.bomb) {
+            tile.special = 'bomb';
+          } else if (Math.random() < SPECIAL_PROB.frozen) {
+            tile.frozen = true;
+          }
+        }
+        return tile;
+      }
+
+      function cloneTile(tile) {
+        return {
+          id: tile.id,
+          row: tile.row,
+          col: tile.col,
+          element: tile.element,
+          level: tile.level,
+          special: tile.special,
+          frozen: tile.frozen
+        };
+      }
+
+      function fillBoard() {
+        grid = new Array(BOARD_SIZE).fill(null).map(() => new Array(BOARD_SIZE).fill(null));
+        let attempts = 0;
+        do {
+          attempts++;
+          for (let r = 0; r < BOARD_SIZE; r++) {
+            for (let c = 0; c < BOARD_SIZE; c++) {
+              grid[r][c] = createTile(r, c, 1);
+            }
+          }
+        } while ((hasInitialMatches() || !hasAnyMoves()) && attempts < 40);
+        renderBoard();
+      }
+
+      function hasInitialMatches() {
+        const matches = findMatches();
+        return matches.length > 0;
+      }
+
+      function renderBoard() {
+        for (let r = 0; r < BOARD_SIZE; r++) {
+          for (let c = 0; c < BOARD_SIZE; c++) {
+            const tile = grid[r][c];
+            const btn = tileEls[r][c];
+            if (!tile) {
+              btn.classList.add('empty');
+              btn.style.background = 'transparent';
+              btn.textContent = '';
+              continue;
+            }
+            btn.classList.remove('empty', 'highlight', 'chain-surge');
+            btn.dataset.row = tile.row;
+            btn.dataset.col = tile.col;
+            btn.dataset.level = tile.level;
+            btn.dataset.element = tile.element;
+            btn.dataset.special = tile.special || '';
+            btn.classList.toggle('selected', selectedTile && selectedTile.id === tile.id);
+            btn.classList.toggle('frozen', !!tile.frozen);
+            btn.classList.toggle('special-bomb', tile.special === 'bomb');
+            btn.classList.toggle('special-rainbow', tile.special === 'rainbow');
+            const palette = elements[tile.element];
+            const grad = `linear-gradient(145deg, ${palette.colors[0]}, ${palette.colors[1]})`;
+            btn.style.background = grad;
+            btn.style.boxShadow = `0 12px 20px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255,0.12), inset 0 0 18px ${palette.glow}`;
+            const stage = evolutionStages.find((st) => st.level === tile.level) || evolutionStages[evolutionStages.length - 1];
+            btn.innerHTML = `<span class="label">${stage.name}</span><span class="level">Lv${tile.level}・${elements[tile.element].label}</span>`;
+          }
+        }
+      }
+
+      function startGame() {
+        resetStats();
+        initBoardElements();
+        fillBoard();
+        updateCodexUI();
+        updateAchievementsUI();
+        updateRankingUI();
+        updateHUD();
+        startOverlay.classList.add('hidden');
+        resultOverlay.classList.add('hidden');
+        gameActive = true;
+        startTimestamp = performance.now();
+        if (timerFrame) cancelAnimationFrame(timerFrame);
+        timerFrame = requestAnimationFrame(updateTimer);
+        ensureAudio();
+        showStatus('モンスターをスワップして進化させよう！');
+      }
+
+      function resetStats() {
+        score = 0;
+        comboChain = 0;
+        maxCombo = 0;
+        bestLevel = 1;
+        frozenReleased = 0;
+        bombChains = 0;
+        selectedTile = null;
+        busy = false;
+        gameActive = false;
+        particles = [];
+        if (fxCtx) {
+          fxCtx.clearRect(0, 0, fxCanvas.width, fxCanvas.height);
+        }
+        tickParticles.last = null;
+      }
+
+      function updateTimer(now) {
+        if (!gameActive) return;
+        const elapsed = (now - startTimestamp) / 1000;
+        const remaining = Math.max(0, TIME_LIMIT - elapsed);
+        timeEl.textContent = remaining.toFixed(0);
+        const ratio = remaining / TIME_LIMIT;
+        timeBarEl.style.transform = `scaleX(${Math.max(0, ratio)})`;
+        if (remaining <= 0) {
+          finishGame('time');
+        } else {
+          timerFrame = requestAnimationFrame(updateTimer);
+          if (audio) audio.setTempo(1 + (1 - ratio) * 0.8);
+        }
+      }
+
+      function ensureAudio() {
+        if (audio) {
+          audio.start();
+          return;
+        }
+        audio = createAudioSystem();
+        audio.start();
+      }
+
+      function createAudioSystem() {
+        const AudioContext = window.AudioContext || window.webkitAudioContext;
+        if (!AudioContext) {
+          return {
+            start() {},
+            play(name) {},
+            setTempo() {}
+          };
+        }
+        const ctx = new AudioContext();
+        let unlocked = false;
+        let tempo = 1;
+        const beatInterval = 0.8;
+        let nextBeat = 0;
+        function ensureUnlocked() {
+          if (!unlocked) {
+            const osc = ctx.createOscillator();
+            osc.frequency.value = 0;
+            osc.connect(ctx.destination);
+            osc.start();
+            osc.stop(ctx.currentTime + 0.01);
+            unlocked = true;
+          }
+        }
+        function scheduleBeat() {
+          if (ctx.state !== 'running') return;
+          const now = ctx.currentTime;
+          if (now + 0.1 < nextBeat) return;
+          const interval = beatInterval / tempo;
+          nextBeat = Math.max(nextBeat, now);
+          for (let i = 0; i < 2; i++) {
+            const t = nextBeat + i * interval;
+            triggerBass(t);
+            triggerHat(t + interval * 0.5);
+          }
+          nextBeat += interval * 2;
+        }
+        function triggerBass(time) {
+          const osc = ctx.createOscillator();
+          const gain = ctx.createGain();
+          osc.type = 'sawtooth';
+          osc.frequency.setValueAtTime(120, time);
+          osc.frequency.exponentialRampToValueAtTime(60, time + 0.3 / tempo);
+          gain.gain.setValueAtTime(0.18, time);
+          gain.gain.exponentialRampToValueAtTime(0.001, time + 0.4 / tempo);
+          osc.connect(gain).connect(ctx.destination);
+          osc.start(time);
+          osc.stop(time + 0.5 / tempo);
+        }
+        function triggerHat(time) {
+          const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.08, ctx.sampleRate);
+          const data = buffer.getChannelData(0);
+          for (let i = 0; i < data.length; i++) {
+            data[i] = Math.random() * 2 - 1;
+          }
+          const noise = ctx.createBufferSource();
+          noise.buffer = buffer;
+          const filter = ctx.createBiquadFilter();
+          filter.type = 'highpass';
+          filter.frequency.value = 5000;
+          const gain = ctx.createGain();
+          gain.gain.setValueAtTime(0.12, time);
+          gain.gain.exponentialRampToValueAtTime(0.001, time + 0.05 / tempo);
+          noise.connect(filter).connect(gain).connect(ctx.destination);
+          noise.start(time);
+          noise.stop(time + 0.07 / tempo);
+        }
+        function play(name) {
+          ensureUnlocked();
+          const now = ctx.currentTime;
+          if (name === 'match') {
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'triangle';
+            osc.frequency.setValueAtTime(420, now);
+            osc.frequency.exponentialRampToValueAtTime(240, now + 0.25);
+            gain.gain.setValueAtTime(0.25, now);
+            gain.gain.exponentialRampToValueAtTime(0.001, now + 0.28);
+            osc.connect(gain).connect(ctx.destination);
+            osc.start(now);
+            osc.stop(now + 0.3);
+          } else if (name === 'evolve') {
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'sine';
+            osc.frequency.setValueAtTime(520, now);
+            osc.frequency.linearRampToValueAtTime(840, now + 0.32);
+            gain.gain.setValueAtTime(0.28, now);
+            gain.gain.exponentialRampToValueAtTime(0.001, now + 0.4);
+            osc.connect(gain).connect(ctx.destination);
+            osc.start(now);
+            osc.stop(now + 0.45);
+          } else if (name === 'fail') {
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'square';
+            osc.frequency.setValueAtTime(200, now);
+            osc.frequency.linearRampToValueAtTime(140, now + 0.2);
+            gain.gain.setValueAtTime(0.2, now);
+            gain.gain.linearRampToValueAtTime(0.001, now + 0.2);
+            osc.connect(gain).connect(ctx.destination);
+            osc.start(now);
+            osc.stop(now + 0.22);
+          } else if (name === 'combo') {
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'sine';
+            osc.frequency.setValueAtTime(660, now);
+            osc.frequency.linearRampToValueAtTime(1040, now + 0.18);
+            gain.gain.setValueAtTime(0.18, now);
+            gain.gain.linearRampToValueAtTime(0.001, now + 0.2);
+            osc.connect(gain).connect(ctx.destination);
+            osc.start(now);
+            osc.stop(now + 0.22);
+          }
+        }
+        function start() {
+          ctx.resume().catch(() => {});
+          ensureUnlocked();
+          nextBeat = ctx.currentTime;
+          if ('requestAudioWorklet' in ctx) {
+            // ignore
+          }
+          const loop = () => {
+            if (ctx.state === 'running') {
+              scheduleBeat();
+            }
+            requestAnimationFrame(loop);
+          };
+          requestAnimationFrame(loop);
+        }
+        function setTempo(value) {
+          tempo = Math.max(0.5, Math.min(2.4, value));
+        }
+        return { start, play, setTempo };
+      }
+
+      function updateHUD() {
+        scoreEl.textContent = Math.floor(score).toLocaleString('ja-JP');
+        maxComboEl.textContent = maxCombo.toString();
+        const stage = evolutionStages.find((st) => st.level === bestLevel) || evolutionStages[evolutionStages.length - 1];
+        maxEvolutionEl.textContent = `${stage.name} (Lv${stage.level})`;
+      }
+
+      function handlePointerDown(event) {
+        if (!gameActive || busy) return;
+        const btn = event.currentTarget;
+        const row = Number(btn.dataset.row);
+        const col = Number(btn.dataset.col);
+        const tile = grid[row][col];
+        if (!tile || tile.frozen) {
+          showStatus(tile ? '凍結中！隣で揃えて解除しよう。' : '');
+          return;
+        }
+        pointerState = {
+          id: event.pointerId,
+          startTile: tile,
+          startX: event.clientX,
+          startY: event.clientY,
+          swapped: false
+        };
+        btn.setPointerCapture(event.pointerId);
+        selectTile(tile);
+      }
+
+      function handlePointerMove(event) {
+        if (!pointerState || pointerState.id !== event.pointerId || pointerState.swapped || busy || !gameActive) return;
+        const dx = event.clientX - pointerState.startX;
+        const dy = event.clientY - pointerState.startY;
+        const threshold = 20;
+        if (Math.abs(dx) < threshold && Math.abs(dy) < threshold) return;
+        const tile = pointerState.startTile;
+        let target = null;
+        if (Math.abs(dx) > Math.abs(dy)) {
+          const dir = dx > 0 ? 1 : -1;
+          if (withinBounds(tile.row, tile.col + dir)) target = grid[tile.row][tile.col + dir];
+        } else {
+          const dir = dy > 0 ? 1 : -1;
+          if (withinBounds(tile.row + dir, tile.col)) target = grid[tile.row + dir][tile.col];
+        }
+        if (target && !target.frozen) {
+          pointerState.swapped = true;
+          attemptSwap(tile, target);
+        }
+      }
+
+      function handlePointerUp(event) {
+        if (pointerState && pointerState.id === event.pointerId) {
+          const tile = pointerState.startTile;
+          if (!pointerState.swapped && tile && !tile.frozen && !busy && gameActive) {
+            handleTileSelection(tile);
+          }
+          pointerState = null;
+        }
+        const btn = event.currentTarget;
+        if (btn && event.pointerId) {
+          try { btn.releasePointerCapture(event.pointerId); } catch (err) {}
+        }
+      }
+
+      function handleTileSelection(tile) {
+        if (!selectedTile) {
+          selectTile(tile);
+          return;
+        }
+        if (selectedTile.id === tile.id) {
+          selectTile(null);
+          return;
+        }
+        if (isAdjacent(selectedTile, tile)) {
+          attemptSwap(selectedTile, tile);
+        } else {
+          selectTile(tile);
+        }
+      }
+
+      function handleTileKey(event) {
+        if (!gameActive || busy) return;
+        const row = Number(this.dataset.row);
+        const col = Number(this.dataset.col);
+        const tile = grid[row][col];
+        if (!tile || tile.frozen) return;
+        const key = event.key;
+        let target = null;
+        if (key === 'Enter' || key === ' ') {
+          event.preventDefault();
+          handleTileSelection(tile);
+          return;
+        }
+        if (key === 'ArrowUp') target = withinBounds(row - 1, col) ? grid[row - 1][col] : null;
+        if (key === 'ArrowDown') target = withinBounds(row + 1, col) ? grid[row + 1][col] : null;
+        if (key === 'ArrowLeft') target = withinBounds(row, col - 1) ? grid[row][col - 1] : null;
+        if (key === 'ArrowRight') target = withinBounds(row, col + 1) ? grid[row][col + 1] : null;
+        if (target && !target.frozen) {
+          event.preventDefault();
+          attemptSwap(tile, target);
+        }
+      }
+
+      function selectTile(tile) {
+        selectedTile = tile;
+        renderBoard();
+      }
+
+      function attemptSwap(a, b) {
+        if (!gameActive || busy) return;
+        if (!a || !b) return;
+        if (a.frozen || b.frozen) return;
+        comboChain = 0;
+        busy = true;
+        swapTiles(a, b);
+        renderBoard();
+        const matches = findMatches();
+        if (matches.length === 0) {
+          swapTiles(a, b);
+          renderBoard();
+          busy = false;
+          selectTile(null);
+          if (audio) audio.play('fail');
+          return;
+        }
+        resolveMatches(matches).then(() => {
+          busy = false;
+          selectTile(null);
+        });
+      }
+
+      function swapTiles(a, b) {
+        const tempRow = a.row;
+        const tempCol = a.col;
+        grid[a.row][a.col] = b;
+        grid[b.row][b.col] = a;
+        a.row = b.row;
+        a.col = b.col;
+        b.row = tempRow;
+        b.col = tempCol;
+      }
+      function withinBounds(row, col) {
+        return row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
+      }
+
+      function isAdjacent(a, b) {
+        return Math.abs(a.row - b.row) + Math.abs(a.col - b.col) === 1;
+      }
+
+      function findMatches() {
+        const groups = [];
+        const pushMatch = (tiles) => {
+          const realTiles = tiles.filter((t) => t.special !== 'rainbow');
+          if (tiles.length >= 3 && realTiles.length > 0) {
+            const base = realTiles[0];
+            groups.push({
+              tiles: new Set(tiles),
+              element: base.element,
+              level: base.level
+            });
+          }
+        };
+
+        // horizontal
+        for (let r = 0; r < BOARD_SIZE; r++) {
+          let sequence = [];
+          let base = null;
+          let hasReal = false;
+          for (let c = 0; c < BOARD_SIZE; c++) {
+            const tile = grid[r][c];
+            if (!tile) {
+              finalize();
+              continue;
+            }
+            const tileBase = tile.special === 'rainbow' ? null : { element: tile.element, level: tile.level };
+            if (sequence.length === 0) {
+              sequence = [tile];
+              if (tileBase) {
+                base = tileBase;
+                hasReal = true;
+              } else {
+                base = null;
+                hasReal = false;
+              }
+            } else if (!tileBase) {
+              sequence.push(tile);
+            } else if (!base) {
+              base = tileBase;
+              hasReal = true;
+              sequence.push(tile);
+            } else if (base.element === tileBase.element && base.level === tileBase.level) {
+              sequence.push(tile);
+              hasReal = true;
+            } else {
+              finalize();
+              sequence = [tile];
+              base = tileBase;
+              hasReal = true;
+            }
+          }
+          finalize();
+
+          function finalize() {
+            if (sequence.length >= 3 && hasReal) {
+              pushMatch([...sequence]);
+            }
+            sequence = [];
+            base = null;
+            hasReal = false;
+          }
+        }
+
+        // vertical
+        for (let c = 0; c < BOARD_SIZE; c++) {
+          let sequence = [];
+          let base = null;
+          let hasReal = false;
+          for (let r = 0; r < BOARD_SIZE; r++) {
+            const tile = grid[r][c];
+            if (!tile) {
+              finalize();
+              continue;
+            }
+            const tileBase = tile.special === 'rainbow' ? null : { element: tile.element, level: tile.level };
+            if (sequence.length === 0) {
+              sequence = [tile];
+              if (tileBase) {
+                base = tileBase;
+                hasReal = true;
+              } else {
+                base = null;
+                hasReal = false;
+              }
+            } else if (!tileBase) {
+              sequence.push(tile);
+            } else if (!base) {
+              base = tileBase;
+              hasReal = true;
+              sequence.push(tile);
+            } else if (base.element === tileBase.element && base.level === tileBase.level) {
+              sequence.push(tile);
+              hasReal = true;
+            } else {
+              finalize();
+              sequence = [tile];
+              base = tileBase;
+              hasReal = true;
+            }
+          }
+          finalize();
+
+          function finalize() {
+            if (sequence.length >= 3 && hasReal) {
+              pushMatch([...sequence]);
+            }
+            sequence = [];
+            base = null;
+            hasReal = false;
+          }
+        }
+
+        if (groups.length <= 1) return groups;
+        const merged = [];
+        for (const group of groups) {
+          let mergedInto = null;
+          for (const existing of merged) {
+            if (intersects(existing.tiles, group.tiles)) {
+              mergedInto = existing;
+              break;
+            }
+          }
+          if (mergedInto) {
+            group.tiles.forEach((tile) => mergedInto.tiles.add(tile));
+            mergedInto.level = Math.max(mergedInto.level, group.level);
+          } else {
+            merged.push({ tiles: new Set(group.tiles), element: group.element, level: group.level });
+          }
+        }
+        return merged;
+      }
+
+      function intersects(setA, setB) {
+        for (const item of setB) {
+          if (setA.has(item)) return true;
+        }
+        return false;
+      }
+
+      function resolveMatches(initialMatches) {
+        let promise = Promise.resolve();
+        let localBombUsed = false;
+        const processCascade = (matches) => {
+          if (!matches || matches.length === 0) {
+            comboChain = 0;
+            return Promise.resolve();
+          }
+          comboChain += 1;
+          maxCombo = Math.max(maxCombo, comboChain);
+          showCombo(comboChain);
+          if (audio) audio.play(comboChain > 1 ? 'combo' : 'match');
+          bodyShake();
+          highlightMatches(matches);
+          const scoreGain = applyMatchEffects(matches);
+          score += scoreGain * (1 + (comboChain - 1) * COMBO_STEP);
+          updateHUD();
+          return delay(260)
+            .then(() => {
+              clearHighlights(matches);
+              collapseBoard();
+              renderBoard();
+              return delay(150);
+            })
+            .then(() => {
+              const nextMatches = findMatches();
+              if (matches.some((m) => Array.from(m.tiles).some((tile) => tile.special === 'bomb'))) {
+                localBombUsed = true;
+              }
+              return processCascade(nextMatches);
+            });
+        };
+        promise = promise.then(() => processCascade(initialMatches)).then(() => {
+          if (localBombUsed) bombChains += 1;
+          if (!hasAnyMoves()) {
+            finishGame('nomove');
+          }
+        });
+        return promise;
+      }
+
+      function highlightMatches(matches) {
+        matches.forEach((match) => {
+          match.tiles.forEach((tile) => {
+            const btn = tileEls[tile.row][tile.col];
+            if (btn) btn.classList.add('highlight');
+          });
+        });
+      }
+
+      function clearHighlights(matches) {
+        matches.forEach((match) => {
+          match.tiles.forEach((tile) => {
+            const btn = tileEls[tile.row][tile.col];
+            if (btn) btn.classList.remove('highlight');
+          });
+        });
+      }
+
+      function applyMatchEffects(matches) {
+        let gained = 0;
+        let tilesToRemove = new Set();
+        let upgradeTargets = [];
+        let frozenToRelease = new Set();
+        matches.forEach((match) => {
+          const tiles = Array.from(match.tiles);
+          const realTiles = tiles.filter((tile) => tile.special !== 'rainbow');
+          const baseTile = realTiles[0] || tiles[0];
+          let target = baseTile;
+          if (tiles.some((tile) => tile.special === 'bomb')) {
+            target = tiles.find((tile) => tile.special !== 'rainbow') || tiles[0];
+          }
+          const nextLevel = Math.min(maxLevel, baseTile.level + 1);
+          const stage = evolutionStages.find((st) => st.level === nextLevel) || evolutionStages[evolutionStages.length - 1];
+          const comboBonus = Math.max(0, comboChain - 1) * 0.35;
+          const basePoints = tiles.length * BASE_SCORE;
+          const bonus = stage.level * 240 + tiles.length * 25;
+          gained += (basePoints + bonus) * (1 + comboBonus);
+          if (tiles.length >= 4 && nextLevel < maxLevel && Math.random() < 0.4) {
+            target.special = 'rainbow';
+          }
+          tiles.forEach((tile) => {
+            if (tile.id !== target.id) {
+              tilesToRemove.add(tile);
+            }
+            if (tile.special === 'bomb') {
+              const neighbors = getNeighbors(tile.row, tile.col, BOMB_RADIUS);
+              neighbors.forEach((neighbor) => {
+                if (neighbor.id !== target.id) tilesToRemove.add(neighbor);
+              });
+              spawnParticles(tile, elements[tile.element].glow, 28);
+            }
+            if (tile.special === 'rainbow') {
+              spawnParticles(tile, 'rgba(255,255,255,0.85)', 20);
+            }
+          });
+          tilesToRemove.forEach((tile) => {
+            const neighbors = getNeighbors(tile.row, tile.col, 1);
+            neighbors.forEach((neighbor) => {
+              if (neighbor.frozen) frozenToRelease.add(neighbor);
+            });
+          });
+          upgradeTargets.push({ tile: target, toLevel: nextLevel });
+          spawnParticles(target, elements[target.element].glow, 36);
+          if (audio) audio.play('evolve');
+          bestLevel = Math.max(bestLevel, nextLevel);
+          codexState[nextLevel] = true;
+        });
+
+        tilesToRemove.forEach((tile) => {
+          grid[tile.row][tile.col] = null;
+        });
+        upgradeTargets.forEach(({ tile, toLevel }) => {
+          tile.level = toLevel;
+          if (tile.special !== 'rainbow') {
+            tile.special = null;
+          }
+          tile.frozen = false;
+        });
+        frozenToRelease.forEach((tile) => {
+          if (tile.frozen) {
+            tile.frozen = false;
+            frozenReleased += 1;
+            spawnParticles(tile, 'rgba(160, 220, 255, 0.9)', 18);
+          }
+        });
+        updateCodexUI();
+        return gained;
+      }
+
+      function collapseBoard() {
+        for (let c = 0; c < BOARD_SIZE; c++) {
+          let writeRow = BOARD_SIZE - 1;
+          for (let r = BOARD_SIZE - 1; r >= 0; r--) {
+            const tile = grid[r][c];
+            if (tile) {
+              if (r !== writeRow) {
+                grid[writeRow][c] = tile;
+                tile.row = writeRow;
+                tile.col = c;
+                grid[r][c] = null;
+              }
+              writeRow--;
+            }
+          }
+          for (let r = writeRow; r >= 0; r--) {
+            const tile = createTile(r, c, 1);
+            grid[r][c] = tile;
+          }
+        }
+      }
+
+      function getNeighbors(row, col, radius = 1) {
+        const neighbors = new Set();
+        for (let dr = -radius; dr <= radius; dr++) {
+          for (let dc = -radius; dc <= radius; dc++) {
+            if (Math.abs(dr) + Math.abs(dc) === 0) continue;
+            const nr = row + dr;
+            const nc = col + dc;
+            if (withinBounds(nr, nc)) {
+              const tile = grid[nr][nc];
+              if (tile) neighbors.add(tile);
+            }
+          }
+        }
+        return neighbors;
+      }
+
+      function delay(ms) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+
+      function showCombo(combo) {
+        comboBannerEl.textContent = `${combo} COMBO!`;
+        comboBannerEl.classList.add('active');
+        if (comboBannerTimer) clearTimeout(comboBannerTimer);
+        comboBannerTimer = setTimeout(() => {
+          comboBannerEl.classList.remove('active');
+        }, 1200);
+      }
+
+      function bodyShake() {
+        document.body.classList.add('shake');
+        setTimeout(() => document.body.classList.remove('shake'), 300);
+      }
+
+      function hasAnyMoves() {
+        for (let r = 0; r < BOARD_SIZE; r++) {
+          for (let c = 0; c < BOARD_SIZE; c++) {
+            const tile = grid[r][c];
+            if (!tile || tile.frozen) continue;
+            const right = withinBounds(r, c + 1) ? grid[r][c + 1] : null;
+            const down = withinBounds(r + 1, c) ? grid[r + 1][c] : null;
+            if (right && !right.frozen && wouldCreateMatch(tile, right)) return true;
+            if (down && !down.frozen && wouldCreateMatch(tile, down)) return true;
+          }
+        }
+        return false;
+      }
+
+      function wouldCreateMatch(tileA, tileB) {
+        swapTiles(tileA, tileB);
+        const matches = findMatches();
+        swapTiles(tileA, tileB);
+        return matches.length > 0;
+      }
+
+      function showStatus(message) {
+        statusBarEl.textContent = message || '';
+        if (!message) return;
+        statusBarEl.style.opacity = '1';
+        setTimeout(() => {
+          statusBarEl.style.opacity = '0.7';
+        }, 1200);
+      }
+
+      function finishGame(reason) {
+        if (!gameActive) return;
+        gameActive = false;
+        cancelAnimationFrame(timerFrame);
+        timerFrame = null;
+        comboBannerEl.classList.remove('active');
+        selectTile(null);
+        updateHUD();
+        const stage = evolutionStages.find((st) => st.level === bestLevel) || evolutionStages[evolutionStages.length - 1];
+        resultScoreEl.textContent = Math.floor(score).toLocaleString('ja-JP');
+        resultEvolutionEl.textContent = `${stage.name} (Lv${stage.level})`;
+        resultComboEl.textContent = maxCombo.toString();
+        let message = '次はさらに進化連鎖を狙おう！';
+        if (reason === 'time') message = '時間切れ！怒涛の進化は続く…';
+        if (reason === 'nomove') message = '動かせる組み合わせがなくなった！新たな進化を求めよう。';
+        resultMessageEl.textContent = message;
+        resultOverlay.classList.remove('hidden');
+        updateAchievements();
+        updateAchievementsUI();
+        updateCodexUI();
+        updateRanking();
+        updateRankingUI();
+        showStatus('');
+      }
+
+      function updateAchievements() {
+        achievementDefs.forEach((ach) => {
+          if (achievementsState[ach.id]) return;
+          if (ach.condition(ctxStats)) {
+            achievementsState[ach.id] = true;
+            showStatus(`実績「${ach.name}」を解除！`);
+          }
+        });
+        saveToStorage(STORAGE_KEYS.achievements, achievementsState);
+      }
+
+      function updateAchievementsUI() {
+        achievementListEl.innerHTML = '';
+        achievementDefs.forEach((ach) => {
+          const div = document.createElement('div');
+          const completed = !!achievementsState[ach.id];
+          div.className = `achievement${completed ? ' completed' : ''}`;
+          div.innerHTML = `<strong>${ach.name}</strong><span>${ach.description}</span><span class="status">${completed ? '解除済み' : '未達成'}</span>`;
+          achievementListEl.appendChild(div);
+        });
+      }
+
+      function updateCodexUI() {
+        codexListEl.innerHTML = '';
+        evolutionStages.forEach((stage) => {
+          const unlocked = stage.level === 1 || codexState[stage.level];
+          const div = document.createElement('div');
+          div.className = `codex-entry${unlocked ? ' unlocked' : ''}`;
+          div.innerHTML = `<div class="name-line"><span>${stage.name}</span><span>Lv${stage.level}</span></div><span>${unlocked ? stage.flair + 'モード解放済み' : '未登録'}</span>`;
+          codexListEl.appendChild(div);
+        });
+        saveToStorage(STORAGE_KEYS.codex, codexState);
+      }
+
+      function updateRanking() {
+        rankingState.push({ score: Math.floor(score), date: new Date().toISOString(), bestLevel, maxCombo });
+        rankingState.sort((a, b) => b.score - a.score);
+        rankingState = rankingState.slice(0, 10);
+        saveToStorage(STORAGE_KEYS.ranking, rankingState);
+      }
+
+      function updateRankingUI() {
+        rankingListEl.innerHTML = '';
+        if (!rankingState.length) {
+          const div = document.createElement('div');
+          div.className = 'ranking-entry';
+          div.innerHTML = '<span>まだスコアはありません。</span>';
+          rankingListEl.appendChild(div);
+          return;
+        }
+        rankingState.forEach((entry, index) => {
+          const stage = evolutionStages.find((st) => st.level === entry.bestLevel) || evolutionStages[evolutionStages.length - 1];
+          const div = document.createElement('div');
+          div.className = 'ranking-entry';
+          const date = new Date(entry.date);
+          const dateText = `${date.getFullYear()}/${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
+          div.innerHTML = `<strong>${index + 1}位</strong><span>${entry.score.toLocaleString('ja-JP')} pts</span><span>${stage.name}・最大コンボ${entry.maxCombo}</span><span>${dateText}</span>`;
+          rankingListEl.appendChild(div);
+        });
+      }
+
+      function spawnParticles(tile, color, count = 20) {
+        const btn = tileEls[tile.row][tile.col];
+        if (!btn) return;
+        const rect = btn.getBoundingClientRect();
+        const boardRect = boardEl.getBoundingClientRect();
+        const cx = rect.left + rect.width / 2 - boardRect.left;
+        const cy = rect.top + rect.height / 2 - boardRect.top;
+        for (let i = 0; i < count; i++) {
+          particles.push({
+            x: cx,
+            y: cy,
+            vx: (Math.random() - 0.5) * 180,
+            vy: (Math.random() - 0.5) * 180 - 40,
+            life: 0.6 + Math.random() * 0.4,
+            age: 0,
+            color: color
+          });
+        }
+        if (particles.length > 0) requestAnimationFrame(tickParticles);
+      }
+
+      function tickParticles(timestamp) {
+        if (!fxCtx) return;
+        if (!tickParticles.last) tickParticles.last = timestamp;
+        const dt = Math.min(0.05, (timestamp - tickParticles.last) / 1000);
+        tickParticles.last = timestamp;
+        const boardRect = boardEl.getBoundingClientRect();
+        resizeFxCanvas();
+        fxCtx.clearRect(0, 0, fxCanvas.width, fxCanvas.height);
+        particles = particles.filter((p) => {
+          p.age += dt;
+          if (p.age > p.life) return false;
+          p.x += p.vx * dt;
+          p.y += p.vy * dt;
+          p.vy += 360 * dt;
+          const alpha = 1 - p.age / p.life;
+          fxCtx.fillStyle = colorWithAlpha(p.color, alpha);
+          fxCtx.beginPath();
+          fxCtx.arc(p.x, p.y, 4 * alpha + 1, 0, Math.PI * 2);
+          fxCtx.fill();
+          return true;
+        });
+        if (particles.length > 0) {
+          requestAnimationFrame(tickParticles);
+        } else {
+          tickParticles.last = null;
+        }
+      }
+
+      function colorWithAlpha(color, alpha) {
+        if (color.startsWith('rgba')) {
+          return color.replace(/rgba\(([^)]+)\)/, (match, values) => {
+            const parts = values.split(',').map((v) => v.trim());
+            return `rgba(${parts[0]}, ${parts[1]}, ${parts[2]}, ${alpha.toFixed(2)})`;
+          });
+        }
+        if (color.startsWith('#')) {
+          const bigint = parseInt(color.slice(1), 16);
+          const r = (bigint >> 16) & 255;
+          const g = (bigint >> 8) & 255;
+          const b = bigint & 255;
+          return `rgba(${r}, ${g}, ${b}, ${alpha.toFixed(2)})`;
+        }
+        return color;
+      }
+
+      function resizeFxCanvas() {
+        const rect = boardEl.getBoundingClientRect();
+        fxCanvas.width = rect.width;
+        fxCanvas.height = rect.height;
+      }
+
+      function handleWindowResize() {
+        resizeFxCanvas();
+      }
+
+      function bindEvents() {
+        window.addEventListener('resize', handleWindowResize);
+        startBtn.addEventListener('click', () => {
+          startGame();
+        });
+        retryBtn.addEventListener('click', () => {
+          startGame();
+        });
+        restartBtn.addEventListener('click', () => {
+          startGame();
+        });
+        boardEl.addEventListener('contextmenu', (e) => e.preventDefault());
+      }
+
+      function init() {
+        initBoardElements();
+        updateCodexUI();
+        updateAchievementsUI();
+        updateRankingUI();
+        bindEvents();
+      }
+
+      init();
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new Swap Monsters evolution puzzle with match-3 fusion mechanics, combos, progression, achievements, and local ranking
- render particle effects, combo feedback, special items (bombs, rainbow egg), and an audio loop for matches and evolutions
- expose the new game from the main menu

## Testing
- not run (HTML/JS game)


------
https://chatgpt.com/codex/tasks/task_e_68d2a5ce9f508327ac06bdaac483cf47