### PR TITLE
Improve responsive layout across pages

### DIFF
--- a/deadzone.html
+++ b/deadzone.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>デッドゾーン：サバイバル</title>
   <style>
     :root {
@@ -42,7 +43,12 @@
     }
     .app-shell {
       position: relative;
-      width: min(1180px, 100%);
+      width: 100%;
+      max-width: 1180px;
+      --frame-max-width: 1180px;
+      --frame-horizontal-gap: var(--page-padding);
+      --frame-vertical-gap: var(--page-padding);
+      --frame-min-width: 280px;
       aspect-ratio: 16 / 9;
       background: rgba(6, 10, 18, 0.92);
       border-radius: clamp(0.8rem, 1.6vw, 1.4rem);
@@ -394,12 +400,15 @@
       to { opacity: 1; transform: translateY(0); }
     }
     @media (max-width: 720px) {
-      body { padding: 0; }
+      body {
+        padding: 0;
+        align-items: stretch;
+        justify-content: flex-start;
+      }
       .app-shell {
+        --frame-horizontal-gap: 0px;
+        --frame-vertical-gap: 0px;
         border-radius: 0;
-        width: 100vw;
-        height: 100vh;
-        aspect-ratio: auto;
       }
       .hud-layer {
         padding: 1rem;
@@ -410,8 +419,8 @@
     }
   </style>
 </head>
-<body>
-  <div class="app-shell" id="appShell">
+<body class="mobile-full-bleed">
+  <div class="app-shell responsive-frame responsive-frame--wide" id="appShell">
     <canvas id="gameCanvas" width="1280" height="720" aria-label="ゲーム画面"></canvas>
     <div class="hud-layer" aria-live="polite">
       <div class="hud-top">

--- a/echoes.html
+++ b/echoes.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>エコーズ・オブ・シティ</title>
   <style>
     :root {
@@ -40,7 +41,12 @@
     }
     .app {
       position: relative;
-      width: min(1100px, 100%);
+      width: 100%;
+      max-width: 1100px;
+      --frame-max-width: 1100px;
+      --frame-horizontal-gap: var(--page-padding);
+      --frame-vertical-gap: var(--page-padding);
+      --frame-min-width: 280px;
       aspect-ratio: 16 / 9;
       background: rgba(5,9,14,0.85);
       border-radius: 1.2rem;
@@ -364,7 +370,7 @@
       body {
         flex-direction: column;
         justify-content: flex-start;
-        align-items: center;
+        align-items: stretch;
       }
     }
 
@@ -533,8 +539,8 @@
     }
   </style>
 </head>
-<body>
-  <div class="app">
+<body class="mobile-full-bleed">
+  <div class="app responsive-frame responsive-frame--wide">
     <canvas id="game" width="960" height="540"></canvas>
     <div class="hud-layer">
       <div class="top-stats">

--- a/floor99.html
+++ b/floor99.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>フロア99</title>
   <style>
     :root {
@@ -181,7 +182,12 @@
     }
     .tower-stage {
       position: relative;
-      width: min(520px, 94vw);
+      width: 100%;
+      max-width: 520px;
+      --frame-max-width: 520px;
+      --frame-aspect: 0.6666667;
+      --frame-horizontal-gap: clamp(1rem, 4vw, 2.5rem);
+      --frame-vertical-gap: calc(clamp(1rem, 4vw, 2.5rem) + 8rem);
       aspect-ratio: 2 / 3;
       background: rgba(12,18,28,0.82);
       border-radius: 1.4rem;
@@ -296,7 +302,11 @@
       }
       .hud-left { justify-content: center; }
       .hud-right { justify-content: center; }
-      .tower-stage { width: min(92vw, 480px); }
+      .tower-stage {
+        max-width: min(92vw, 480px);
+        --frame-horizontal-gap: clamp(1rem, 4vw, 2.5rem);
+        --frame-vertical-gap: calc(clamp(1rem, 4vw, 2.5rem) + 7rem);
+      }
     }
   </style>
 </head>
@@ -331,7 +341,7 @@
       </div>
     </header>
     <main class="tower-main">
-      <div class="tower-stage">
+      <div class="tower-stage responsive-frame responsive-frame--tower">
         <canvas id="towerCanvas" width="480" height="720" aria-label="ゲーム画面"></canvas>
         <div class="tower-overlay" id="startOverlay">
           <h1>フロア99</h1>

--- a/gravityflip.html
+++ b/gravityflip.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>グラビティ・フリップランナー</title>
   <style>
     :root {
@@ -39,7 +40,12 @@
     }
     .app {
       position: relative;
-      width: min(1100px, 100%);
+      width: 100%;
+      max-width: 1100px;
+      --frame-max-width: 1100px;
+      --frame-horizontal-gap: var(--page-padding);
+      --frame-vertical-gap: var(--page-padding);
+      --frame-min-width: 280px;
       aspect-ratio: 16 / 9;
       background: rgba(4, 8, 14, 0.94);
       border-radius: clamp(1rem, 2vw, 1.4rem);
@@ -314,6 +320,12 @@
     @keyframes toast-out {
       to { opacity: 0; transform: translateY(10px); }
     }
+    @media (max-width: 900px), (max-height: 700px) {
+      body {
+        align-items: stretch;
+        justify-content: flex-start;
+      }
+    }
     @media (max-width: 680px) {
       .hud-card { flex: 1; min-width: auto; }
       .combo-meter { width: 100%; }
@@ -331,8 +343,8 @@
     }
   </style>
 </head>
-<body>
-  <div class="app" id="app" aria-label="グラビティ・フリップランナー">
+<body class="mobile-full-bleed">
+  <div class="app responsive-frame responsive-frame--wide" id="app" aria-label="グラビティ・フリップランナー">
     <canvas id="gameCanvas" width="1280" height="720" role="img" aria-label="ゲーム画面"></canvas>
     <div class="hud" aria-live="polite">
       <div class="hud-row">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>ミニゲームセレクト</title>
   <style>
     :root {
@@ -36,15 +37,19 @@
     }
     .menu-screen {
       width: min(960px, 100%);
+      max-height: max(0px, calc(var(--viewport-height, 100dvh) - 2 * var(--page-padding)));
       background: rgba(12,18,28,0.82);
       border-radius: 1.25rem;
       box-shadow: 0 24px 60px rgba(0,0,0,0.4);
       display: flex;
       justify-content: center;
+      overflow: hidden;
     }
     .menu-content {
       width: 100%;
       padding: clamp(2rem, 5vw, 3rem);
+      max-height: max(0px, calc(var(--viewport-height, 100dvh) - 2 * var(--page-padding)));
+      overflow-y: auto;
       display: flex;
       flex-direction: column;
       gap: clamp(1.5rem, 4vw, 2.5rem);
@@ -117,7 +122,7 @@
       cursor: not-allowed;
       opacity: 0.5;
     }
-    @media (max-width: 640px) {
+    @media (max-width: 640px), (max-height: 720px) {
       body {
         justify-content: flex-start;
         align-items: stretch;

--- a/maze.html
+++ b/maze.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>一筆書き迷路</title>
   <style>
     :root {
@@ -102,7 +103,12 @@
     }
     .canvas-shell {
       position: relative;
-      width: min(90vw, 720px);
+      width: 100%;
+      max-width: 720px;
+      --frame-max-width: 720px;
+      --frame-aspect: 1;
+      --frame-horizontal-gap: 1rem;
+      --frame-vertical-gap: calc(1rem + 9rem);
       aspect-ratio: 1 / 1;
       background: rgba(12,18,28,0.75);
       border-radius: 1rem;
@@ -263,7 +269,11 @@
         justify-content: center;
       }
       header .stats { width: 100%; }
-      .canvas-shell { width: min(100%, 520px); }
+      .canvas-shell {
+        max-width: min(100%, 520px);
+        --frame-horizontal-gap: 0.75rem;
+        --frame-vertical-gap: calc(0.75rem + 8rem);
+      }
     }
   </style>
 </head>
@@ -294,7 +304,7 @@
     </div>
   </header>
   <main>
-    <div class="canvas-shell" id="canvasShell">
+    <div class="canvas-shell responsive-frame responsive-frame--square" id="canvasShell">
       <canvas id="mazeCanvas" aria-label="一筆書き迷路"></canvas>
       <div class="overlay" id="homeOverlay" role="dialog" aria-modal="true">
         <h1>一筆書き迷路</h1>

--- a/metrorunner.html
+++ b/metrorunner.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>メトロランナー：リミックス</title>
   <style>
     :root {
@@ -42,7 +43,12 @@
     }
     .app {
       position: relative;
-      width: min(1100px, 100%);
+      width: 100%;
+      max-width: 1100px;
+      --frame-max-width: 1100px;
+      --frame-horizontal-gap: var(--page-padding);
+      --frame-vertical-gap: var(--page-padding);
+      --frame-min-width: 280px;
       aspect-ratio: 16 / 9;
       background: rgba(6,10,18,0.9);
       border-radius: 1.2rem;
@@ -377,9 +383,10 @@
     body.orientation-blocked {
       overflow: hidden;
     }
-    @media (max-width: 720px) {
+    @media (max-width: 720px), (max-height: 700px) {
       body {
         align-items: flex-start;
+        justify-content: flex-start;
       }
       .app {
         border-radius: 0.9rem;
@@ -450,8 +457,8 @@
     }
   </style>
 </head>
-<body>
-  <div class="app">
+<body class="mobile-full-bleed">
+  <div class="app responsive-frame responsive-frame--wide">
     <canvas id="gameCanvas" width="1280" height="720" aria-label="ゲーム画面"></canvas>
     <div class="hud" aria-hidden="true">
       <div class="hud-row">

--- a/shooter.html
+++ b/shooter.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>弾幕サーファー</title>
   <style>
     :root {
@@ -143,7 +144,13 @@
     }
     .shooter-canvas-shell {
       position: relative;
-      width: min(90vw, 520px);
+      width: 100%;
+      max-width: 520px;
+      --frame-max-width: 520px;
+      --frame-aspect: 0.5625;
+      --frame-horizontal-gap: 1rem;
+      --frame-vertical-gap: calc(1rem + 7.5rem);
+      --frame-min-width: 260px;
       aspect-ratio: 9 / 16;
       background: rgba(12,18,28,0.78);
       border-radius: 1rem;
@@ -220,7 +227,7 @@
       opacity: 1;
       transform: translate(-50%, -0.25rem);
     }
-    @media (max-width: 768px) {
+    @media (max-width: 768px), (max-height: 720px) {
       .shooter-topbar {
         flex-direction: column;
         align-items: stretch;
@@ -233,7 +240,9 @@
         width: 100%;
       }
       .shooter-canvas-shell {
-        width: min(100%, 420px);
+        max-width: min(420px, 100%);
+        --frame-horizontal-gap: 0.75rem;
+        --frame-vertical-gap: calc(0.75rem + 6.5rem);
       }
     }
   </style>
@@ -267,7 +276,7 @@
       </div>
     </div>
     <div class="shooter-main">
-      <div class="shooter-canvas-shell" id="shooterCanvasShell">
+      <div class="shooter-canvas-shell responsive-frame responsive-frame--tall" id="shooterCanvasShell">
         <canvas id="shooterCanvas" aria-label="弾幕サーファー"></canvas>
         <div class="shooter-overlay" id="shooterStartOverlay" role="dialog" aria-modal="true">
           <div class="shooter-panel">

--- a/skydive.html
+++ b/skydive.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>スカイダイブ・インフェルノ</title>
   <style>
     :root {
@@ -39,7 +40,12 @@
     }
     .app {
       position: relative;
-      width: min(1100px, 100%);
+      width: 100%;
+      max-width: 1100px;
+      --frame-max-width: 1100px;
+      --frame-horizontal-gap: var(--page-padding);
+      --frame-vertical-gap: var(--page-padding);
+      --frame-min-width: 280px;
       aspect-ratio: 16 / 9;
       background: rgba(6, 10, 18, 0.92);
       border-radius: clamp(1rem, 2vw, 1.4rem);
@@ -321,6 +327,12 @@
       from { opacity: 0.7; transform: translate(-50%, -50%) scale(0.6); }
       to { opacity: 0; transform: translate(-50%, -50%) scale(1.8); }
     }
+    @media (max-width: 900px), (max-height: 700px) {
+      body {
+        align-items: stretch;
+        justify-content: flex-start;
+      }
+    }
     @media (max-width: 840px) {
       .hud {
         padding: clamp(0.6rem, 4vw, 1.2rem);
@@ -331,8 +343,8 @@
     }
   </style>
 </head>
-<body>
-  <div class="app" id="app">
+<body class="mobile-full-bleed">
+  <div class="app responsive-frame responsive-frame--wide" id="app">
     <canvas id="gameCanvas" width="960" height="540" aria-label="スカイダイブ・インフェルノのゲーム画面"></canvas>
     <div class="hud" aria-live="polite">
       <div class="hud-row">

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -1,0 +1,54 @@
+:root {
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --viewport-height: calc(100dvh - var(--safe-top) - var(--safe-bottom));
+  --viewport-width: calc(100vw - var(--safe-left) - var(--safe-right));
+}
+
+.responsive-frame {
+  --frame-aspect: 1;
+  --frame-max-width: 100%;
+  --frame-horizontal-gap: 0px;
+  --frame-vertical-gap: 0px;
+  --frame-min-width: 0px;
+  --frame-min-height: 0px;
+  --_responsive-width: max(
+    var(--frame-min-width),
+    var(--viewport-width) - 2 * var(--frame-horizontal-gap)
+  );
+  --_responsive-height: max(
+    var(--frame-min-height),
+    var(--viewport-height) - 2 * var(--frame-vertical-gap)
+  );
+  width: min(
+    var(--frame-max-width),
+    var(--_responsive-width),
+    calc(var(--_responsive-height) * var(--frame-aspect))
+  );
+  max-height: var(--_responsive-height);
+}
+
+.responsive-frame--wide {
+  --frame-aspect: 1.7777778;
+}
+
+.responsive-frame--tall {
+  --frame-aspect: 0.5625;
+}
+
+.responsive-frame--tower {
+  --frame-aspect: 0.6666667;
+}
+
+.responsive-frame--square {
+  --frame-aspect: 1;
+}
+
+@media (max-width: 720px), (max-height: 720px) {
+  .mobile-full-bleed {
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+  }
+}

--- a/swapmonsters.html
+++ b/swapmonsters.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>スワップ・モンスターズ</title>
   <style>
     :root {
@@ -39,7 +40,8 @@
       padding-left: calc(clamp(1rem, 3vw, 2rem) + var(--safe-left));
       padding-right: calc(clamp(1rem, 3vw, 2rem) + var(--safe-right));
       gap: clamp(1rem, 2.5vw, 1.75rem);
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
     header {
       display: grid;
@@ -120,7 +122,9 @@
       box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
     }
     .board {
-      width: min(88vw, 640px);
+      width: 100%;
+      max-width: 640px;
+      max-height: max(280px, calc(var(--viewport-height, 100dvh) - clamp(10rem, 26vw, 18rem)));
       aspect-ratio: 1 / 1;
       display: grid;
       grid-template-columns: repeat(var(--size), 1fr);
@@ -398,13 +402,17 @@
       40% { transform: scale(1.08); }
       100% { transform: scale(1); }
     }
-    @media (max-width: 1024px) {
+    @media (max-width: 1080px) {
       main {
         grid-template-columns: 1fr;
         grid-template-rows: auto auto;
+        align-items: stretch;
       }
-      .board {
-        width: min(94vw, 520px);
+      .board-shell {
+        justify-content: center;
+      }
+      .side-panel {
+        order: -1;
       }
     }
     @media (max-width: 640px) {

--- a/swordsman.html
+++ b/swordsman.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/responsive.css" />
   <title>ぶっ飛ばし剣士</title>
   <style>
     :root {
@@ -151,7 +152,12 @@
     }
     .blade-canvas-shell {
       position: relative;
-      width: min(960px, 95vw);
+      width: 100%;
+      max-width: 960px;
+      --frame-max-width: 960px;
+      --frame-horizontal-gap: clamp(1rem, 4vw, 2.5rem);
+      --frame-vertical-gap: calc(clamp(1rem, 4vw, 2.5rem) + 8.5rem);
+      --frame-min-width: 280px;
       aspect-ratio: 16 / 9;
       background: rgba(12, 18, 28, 0.82);
       border-radius: 1.2rem;
@@ -291,6 +297,9 @@
       .blade-hud { justify-content: center; }
       .hud-item { min-width: 45%; }
       .blade-life { justify-content: center; }
+      .blade-canvas-shell {
+        --frame-vertical-gap: calc(clamp(1rem, 4vw, 2.5rem) + 7rem);
+      }
     }
     @media (max-width: 600px) {
       .blade-stage {
@@ -300,6 +309,8 @@
       .blade-canvas-shell {
         width: 100%;
         max-width: 520px;
+        --frame-horizontal-gap: 1rem;
+        --frame-vertical-gap: 1rem;
         aspect-ratio: auto;
         background: none;
         border-radius: 0;
@@ -382,7 +393,7 @@
       <button id="bladeMute" class="blade-mute" type="button" title="ミュート切替" aria-label="ミュート切替" aria-pressed="false">🔊</button>
     </header>
     <main class="blade-stage">
-      <div class="blade-canvas-shell">
+      <div class="blade-canvas-shell responsive-frame responsive-frame--wide">
         <canvas id="bladeCanvas" width="960" height="540" aria-label="ぶっ飛ばし剣士のゲーム画面"></canvas>
         <div class="blade-overlay" id="bladeTitle" role="dialog" aria-modal="true">
           <h1>ぶっ飛ばし剣士</h1>


### PR DESCRIPTION
## Summary
- add a shared responsive helper stylesheet that exposes viewport-aware frame sizing utilities
- update each game canvas container to consume the responsive sizing helpers and adjust layout rules for small screens
- refine the index menu and swapmonsters board so long pages scroll and controls stack cleanly on narrow devices

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d31c7c74e48327ac760104d45935c4