### PR TITLE
Fix cloneProfile initialization order

### DIFF
--- a/metrorunner.html
+++ b/metrorunner.html
@@ -686,6 +686,10 @@
       ranking: []
     };
 
+    const cloneProfile = obj => (typeof structuredClone === 'function')
+      ? structuredClone(obj)
+      : JSON.parse(JSON.stringify(obj));
+
     let profile = loadProfile();
 
     function shouldShowOrientationNotice() {
@@ -911,8 +915,6 @@
     const pointer = { active: false, startX: 0, startY: 0, startTime: 0 };
 
     const AUDIO = createAudioSystem();
-    const cloneProfile = obj => (typeof structuredClone === 'function') ? structuredClone(obj) : JSON.parse(JSON.stringify(obj));
-
     function loadProfile() {
       try {
         const raw = localStorage.getItem(profileKey);


### PR DESCRIPTION
## Summary
- define cloneProfile before loading the profile so it is available during initialization
- remove the duplicate later declaration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d32c65dcc883278e11aa1ee262586f